### PR TITLE
Added logic to find db api url, added get and post db api curl reques…

### DIFF
--- a/manifests/k6_custom_resource.yaml
+++ b/manifests/k6_custom_resource.yaml
@@ -3,12 +3,12 @@ kind: K6
 metadata:
   name: k6-edamame-test
 spec:
-  parallelism: 4
+  parallelism: 1
   script:
     configMap:
-      name: '4'
-      file: test.js
-  arguments: '--out distributed-statsd'
+      name: "test_id"
+      file: sample_test.js
+  arguments: "--out distributed-statsd"
   runner:
     image: lukeoguro/xk6-statsd:latest
     env:
@@ -21,4 +21,4 @@ spec:
       - name: K6_STATSD_GAUGE_NAMESPACE
         value: $(POD_NAME).
       - name: K6_STATSD_NAMESPACE
-        value: '4'
+        value: "test_id"

--- a/src/commands/getTestIds.js
+++ b/src/commands/getTestIds.js
@@ -1,0 +1,15 @@
+import Spinner from "../utilities/spinner.js";
+import dbApi from "../utilities/dbApi.js";
+
+const getTestIds = (testPath, numVus) => {
+  const spinner = new Spinner("Retrieving all test ids...");
+    dbApi.getTestIds()
+      .then(({stdout}) => {
+        spinner.succeed();
+        console.log(stdout);
+      })
+};
+
+export {
+  getTestIds
+};

--- a/src/commands/runTest.js
+++ b/src/commands/runTest.js
@@ -1,5 +1,4 @@
 import fs from "fs";
-import kubectl from "../utilities/kubectl.js";
 import loadGenerators from "../utilities/loadGenerators.js";
 import Spinner from "../utilities/spinner.js";
 import cluster from "../utilities/cluster.js";

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,5 +1,9 @@
 // num vus per job is arbitrary; update once know desired # 
 const NUM_VUS_PER_POD = 50;
+const POLL_FREQUENCY = 30000;
+const DB_API_PORT = 4444;
+const DB_API_NAME = "db-api-service";
+const DB_API_REGEX = "amazonaws.com";
 const K6_CR_FILE = "k6_custom_resource.yaml";
 const PG_SECRET_FILE = "postgres_secret.yaml";
 const PG_CM_FILE = "postgres_configmap.yaml";
@@ -14,6 +18,10 @@ const EBS_CSI_DRIVER_REGEX = "ebs-csi-controller-sa.*AmazonEKS_EBS_CSI_DriverRol
 
 export {
   NUM_VUS_PER_POD,
+  POLL_FREQUENCY,
+  DB_API_PORT,
+  DB_API_NAME,
+  DB_API_REGEX,
   K6_CR_FILE,
   PG_SECRET_FILE,
   PG_CM_FILE,

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import { init } from "./commands/init.js"
 import { destroyEKSCluster } from "./commands/destroy.js"
 import { runTest } from "./commands/runTest.js"
+import { getTestIds } from "./commands/getTestIds.js";
 
 const args = process.argv.slice(2);
 const firstArg = args[0];
@@ -15,17 +16,20 @@ switch(firstArg) {
   case "init":
     init();
     break;
-  case "run-test":
+  case "run":
     // assumes test is run like so, with the relative filepath being passed in after --file:
-    //  edamame run-test --file ./deployment/test.js --vus 40000
+    //  edamame run test --file ./deployment/test.js --vus 40000
     const filePath = flagValue("--file");
     const numVus = flagValue("--vus");
+    // later: add back (--name) flag to let users associate testId with name of their choice
+    //   then when want to view a test 
     runTest(filePath, numVus);
+    break;
+  case "get":
+    getTestIds();
     break;
   case "teardown":
     destroyEKSCluster();
-    break;
-  case "destroy-all":
     break;
   default:
     // placeholder

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -1,0 +1,60 @@
+import { 
+  DB_API_NAME,
+  DB_API_PORT,
+  DB_API_REGEX
+ } from "../constants/constants.js";
+import kubectl from "./kubectl.js";
+import { promisify } from "util";
+import child_process from "child_process";
+const exec = promisify(child_process.exec);
+
+const dbApi = {
+  newTestId() {
+    return (
+      kubectl.getIps()
+        .then(({stdout}) => {
+          const url = this.findUrl(stdout);
+          return exec(`curl -X POST ${url}/tests`);
+        })
+        .then(({stdout}) => {
+          const testId = stdout.match('[0-9]{1,}');
+          if (testId) {
+            return testId[0];
+          }
+        })
+    );
+  },
+
+  findUrl(stdout) {
+    let url;
+    const services = stdout.split("\n");
+
+    for (let colIdx = 0; colIdx < services.length; colIdx++) {
+      const serviceCols = services[colIdx];
+      if (serviceCols.match(DB_API_NAME)) {
+        const propRows = serviceCols.split(" ");
+
+        for (let rowIdx = 0; rowIdx < propRows.length; rowIdx++) {
+          const prop = propRows[rowIdx];
+          if (prop.match(DB_API_REGEX)) {
+            return  prop + ":" + DB_API_PORT;
+          }
+        }
+      }
+    }
+  },
+
+  getTestIds() {
+    return (
+      kubectl.getIps()
+        .then(({stdout}) => {
+          const url = this.findUrl(stdout);
+          return exec(`curl -X GET ${url}/tests`);
+        })
+    );
+  }
+};
+
+export default dbApi;
+
+

--- a/src/utilities/eksctl.js
+++ b/src/utilities/eksctl.js
@@ -11,6 +11,10 @@ const eksctl = {
     return exec(`eksctl create cluster --name ${CLUSTER_NAME}`);
   },
 
+  clusterDesc() {
+    return exec(`eksctl get cluster`);
+  },
+
   createLoadGenGrp() {
     return exec(
       `eksctl create nodegroup --cluster=${CLUSTER_NAME} `+ 

--- a/src/utilities/iam.js
+++ b/src/utilities/iam.js
@@ -1,7 +1,4 @@
 import { EBS_CSI_DRIVER_REGEX } from "../constants/constants.js";
-import child_process from "child_process";
-import { promisify } from "util";
-const exec = promisify(child_process.exec);
 
 const iam = {
   ebsRole(stdout) {
@@ -14,8 +11,7 @@ const iam = {
     const oidc = oidcAndList[0].split("\n")[0];
     const list = oidcAndList[1];
     return list.match(oidc) === null ? false : true;
-  },
-
+  }
 };
 
 export default iam;

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -21,11 +21,23 @@ const kubectl = {
     return exec(`kubectl delete -f ${path}`);
   },
 
+  getIps() {
+    return exec(`kubectl get svc`);
+  },
+
   createConfigMap(path) {
     // added this b/c psql-host key wasn't being properly registered by db api
     // deployment even though could see psql-host in psql-configmap when used
     // createConfigMapWithName to create psql configmap
     return exec(`kubectl create -f ${path}`);
+  },
+
+  deletePv(type, name) {
+    return exec(`kubectl delete ${type} ${name}`);
+  },
+
+  getPv(type, name) {
+    return exec(`kubectl get ${type} ${name}`);
   },
 
   applyManifest(path) {
@@ -35,7 +47,7 @@ const kubectl = {
   getPods() {
     return exec(`kubectl get pods`);
   }
-
 };
 
 export default kubectl;
+

--- a/src/utilities/loadGenerators.js
+++ b/src/utilities/loadGenerators.js
@@ -1,7 +1,10 @@
 import child_process from "child_process";
 import { promisify } from "util";
 import kubectl from "./kubectl.js";
-import { K6_TEST_POD_REGEX } from "../constants/constants.js";
+import { 
+  K6_TEST_POD_REGEX,
+  POLL_FREQUENCY
+} from "../constants/constants.js";
 import manifest from "./manifest.js";
 const exec = promisify(child_process.exec);
 
@@ -47,7 +50,7 @@ const loadGenerators = {
         resolve();
       // do we want to poll more/less frequently than 30 seconds?
       //  or try to switch to an event-driven approach...
-      }, 30000);
+      }, POLL_FREQUENCY);
     });
   }
 };

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -23,6 +23,11 @@ const manifest = {
     files.write(K6_CR_FILE, k6CrData);
   },
 
+  latestK6TestId() {
+    const data = files.read(K6_CR_FILE);
+    return data.spec.script.configMap.name;
+  },
+
   setPgPw(pw) {
     const pgSecret = files.read(PG_SECRET_FILE);
     pgSecret.data["psql-username"] = this.base64(CLUSTER_NAME);
@@ -41,3 +46,4 @@ const manifest = {
 };
 
 export default manifest;
+


### PR DESCRIPTION
…t logic for the /tests path, so that k6 cr and test configmap name are now being overwritten with dynamic testid, added get tests edamame cli command to retrieve all numerical test ids, updated phasing out k6 logic to delete load test configmap and cr associated with the dynamic k6 test id