### PR TITLE
Added logic to create and apply grafana manifests based on yaml and j…

### DIFF
--- a/manifests/grafana_dashboards.yaml
+++ b/manifests/grafana_dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+providers:
+  - name: "http"
+    orgId: 1
+    folder: ""
+    folderUid: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false #We can probably change this to true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/manifests/grafana_datasource.yaml
+++ b/manifests/grafana_datasource.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+datasources:
+  - name: Postgres
+    type: postgres
+    url: postgres-service:5432
+    database: edamame
+    user:
+    secureJsonData:
+      password:
+    jsonData:
+      sslmode: disable
+      maxOpenConns: 0
+      maxIdleConns: 2
+      connMaxLifetime: 14400
+      postgresVersion: 903
+      timescaledb: false

--- a/manifests/grafana_json_dbs/http_dashboard.json
+++ b/manifests/grafana_json_dbs/http_dashboard.json
@@ -1,0 +1,20 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        }
+      }
+    ]
+  }
+}

--- a/manifests/grafana_json_dbs/test_dashboard.json
+++ b/manifests/grafana_json_dbs/test_dashboard.json
@@ -1,0 +1,20 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        }
+      }
+    ]
+  }
+}

--- a/manifests/k6_custom_resource.yaml
+++ b/manifests/k6_custom_resource.yaml
@@ -3,11 +3,11 @@ kind: K6
 metadata:
   name: k6-edamame-test
 spec:
-  parallelism: 1
+  parallelism: 4
   script:
     configMap:
-      name: "test_id"
-      file: sample_test.js
+      name: "testId"
+      file: test.js
   arguments: "--out distributed-statsd"
   runner:
     image: lukeoguro/xk6-statsd:latest
@@ -21,4 +21,4 @@ spec:
       - name: K6_STATSD_GAUGE_NAMESPACE
         value: $(POD_NAME).
       - name: K6_STATSD_NAMESPACE
-        value: "test_id"
+        value: "testId"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -10,7 +10,13 @@ const init = () => {
     .then(() => userInput.processPassword())
     .then(() => spinner.update("Deploying Grafana, Postgres, & K6 Operator..."))
     .then(() => cluster.deployServersK6Op())
-    .then(() => spinner.succeed("Cluster Configured. You can load test now!"))
+    .then(() => {
+      spinner.succeed("Cluster configured. You can load test now!");
+      /*spinner.succeed(
+        `Cluster Configured. You can load test now! ` +
+        `Access the grafana dashboard at localhost:3000`
+      );*/
+    })
     .catch(err => spinner.fail(`Error creating cluster: ${err}`));
 };
 

--- a/src/commands/runTest.js
+++ b/src/commands/runTest.js
@@ -8,7 +8,7 @@ const runTest = (testPath, numVus) => {
   if (fs.existsSync(testPath)) {
     const spinner = new Spinner("Distributing k6 load test...");
     cluster.launchK6Test(testPath, numVus)
-      .then(() => spinner.update("Starting k6 load test..."))
+      .then(() => spinner.update("Running k6 load test..."))
       .then(() => loadGenerators.pollUntilAllComplete(numVus))
       .then(() => spinner.update("All tests completed; Removing load generators."))
       .then(() => cluster.phaseOutK6())

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,11 +1,18 @@
-// num vus per job is arbitrary; update once know desired # 
 const NUM_VUS_PER_POD = 50;
 const POLL_FREQUENCY = 30000;
 const DB_API_PORT = 4444;
+const GRAF_PORT = 3000;
 const DB_API_NAME = "db-api-service";
 const DB_API_REGEX = "amazonaws.com";
+const GRAF = "grafana.yaml";
+const GRAF_DS_FILE = "grafana_datasource.yaml";
+const GRAF_DB_FILE = "grafana_dashboards.yaml";
+const GRAF_DS = "grafana-datasources";
+const GRAF_DBS = "grafana-dashboards";
+const GRAF_JSON_DBS = "grafana_json_dbs";
 const K6_CR_FILE = "k6_custom_resource.yaml";
 const PG_SECRET_FILE = "postgres_secret.yaml";
+const PG_CM = "psql-configmap";
 const PG_CM_FILE = "postgres_configmap.yaml";
 const PG_SS_FILE = "postgres_statefulset.yaml";
 const STATSITE_FILE = "statsite_deployment.yaml";
@@ -15,10 +22,17 @@ const LOAD_GEN_NODE_GRP = "load-generators";
 const K6_TEST_POD_REGEX = 'k6-edamame-test-[0-9]{1,}';
 const EBS_CSI_DRIVER_REGEX = "ebs-csi-controller-sa.*AmazonEKS_EBS_CSI_DriverRole";
 
-
 export {
   NUM_VUS_PER_POD,
   POLL_FREQUENCY,
+  PG_CM,
+  GRAF,
+  GRAF_DS,
+  GRAF_DBS,
+  GRAF_PORT,
+  GRAF_DS_FILE,
+  GRAF_DB_FILE,
+  GRAF_JSON_DBS,
   DB_API_PORT,
   DB_API_NAME,
   DB_API_REGEX,

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -31,12 +31,13 @@ const dbApi = {
 
     for (let colIdx = 0; colIdx < services.length; colIdx++) {
       const serviceCols = services[colIdx];
+
       if (serviceCols.match(DB_API_NAME)) {
         const propRows = serviceCols.split(" ");
 
         for (let rowIdx = 0; rowIdx < propRows.length; rowIdx++) {
           const prop = propRows[rowIdx];
-          if (prop.match(DB_API_REGEX)) {
+          if (prop && prop.match(DB_API_REGEX)) {
             return  prop + ":" + DB_API_PORT;
           }
         }

--- a/src/utilities/files.js
+++ b/src/utilities/files.js
@@ -14,6 +14,10 @@ const files = {
     return yaml.load(fs.readFileSync(file), 'utf-8');
   },
 
+  fileNames(path) {
+    return fs.readdirSync(path);
+  },
+
   write(fileName, data) {
     const filePath = this.path(fileName);
     fs.writeFileSync(filePath, yaml.dump(data));

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -25,6 +25,19 @@ const kubectl = {
     return exec(`kubectl get svc`);
   },
 
+  configMapExists(name) {
+    return (
+      exec(`kubectl get configmaps`)
+        .then(({stdout}) => {
+          return !!stdout.match(name);
+        })
+    );
+  },
+
+  portForward(service, port1, port2) {
+    return exec(`kubectl port-forward ${service} ${port1}:${port2} & `);
+  }, 
+
   createConfigMap(path) {
     // added this b/c psql-host key wasn't being properly registered by db api
     // deployment even though could see psql-host in psql-configmap when used
@@ -50,4 +63,3 @@ const kubectl = {
 };
 
 export default kubectl;
-

--- a/src/utilities/loadGenerators.js
+++ b/src/utilities/loadGenerators.js
@@ -48,8 +48,6 @@ const loadGenerators = {
 
         clearInterval(interval);
         resolve();
-      // do we want to poll more/less frequently than 30 seconds?
-      //  or try to switch to an event-driven approach...
       }, POLL_FREQUENCY);
     });
   }

--- a/src/utilities/userInput.js
+++ b/src/utilities/userInput.js
@@ -16,9 +16,7 @@ const userInput = {
 
   processPassword() {
     const password = this.getPassword();
-    manifest.setPgPw(password);
-    // do we want users ability to confirm the password they entered?
-    // <> have them re-enter to confirm?
+    manifest.setPgGrafCredentials(password);
   }
 };
 


### PR DESCRIPTION
…son files during the edamame init process, added some additional checks for existing configmaps so that user can re-run edamame init without getting an error stating configmap exists, and added kubectl logic and a placeholder in cluster.js for port forwarding local access to grafana dashboard