### PR TITLE
Delete EBS volumes along with EKS cluster

### DIFF
--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -116,8 +116,9 @@ const cluster = {
     );
   },
 
-  destroy() {
-    return eksctl.destroyCluster();
+  async destroy() {
+    await eksctl.destroyCluster();
+    return eksctl.deleteEBSVolumes();
     /*return (
       //kubectl.deletePv('pv', need_to_get_and_parse_name_first) 
         //.then(() => eksctl.destroyCluster())

--- a/src/utilities/eksctl.js
+++ b/src/utilities/eksctl.js
@@ -80,7 +80,6 @@ const eksctl = {
   async deleteEBSVolumes() {
     let volumes = await exec(`aws ec2 describe-volumes --filter "Name=tag:kubernetes.io/created-for/pvc/name,Values=data-psql-0,grafana-pvc" --query 'Volumes[].VolumeId' --output json`)
     volumes = JSON.parse(volumes.stdout)
-    console.log(volumes)
     return Promise.allSettled(volumes.map(volume => {
       exec(`aws ec2 delete-volume --volume-id ${volume}`)
     }))

--- a/src/utilities/eksctl.js
+++ b/src/utilities/eksctl.js
@@ -75,6 +75,15 @@ const eksctl = {
 
   destroyCluster() {
     return exec(`eksctl delete cluster --name ${CLUSTER_NAME}`);
+  },
+
+  async deleteEBSVolumes() {
+    let volumes = await exec(`aws ec2 describe-volumes --filter "Name=tag:kubernetes.io/created-for/pvc/name,Values=data-psql-0,grafana-pvc" --query 'Volumes[].VolumeId' --output json`)
+    volumes = JSON.parse(volumes.stdout)
+    console.log(volumes)
+    return Promise.allSettled(volumes.map(volume => {
+      exec(`aws ec2 delete-volume --volume-id ${volume}`)
+    }))
   }
 };
 


### PR DESCRIPTION
These changes can be tested by doing the following:

- If you don't have a cluster, create one with `edamame init`
- Teardown the cluster with `edamame teardown`
- Executing the command `aws ec2 describe-volumes` from the terminal should output:
```
{
    "Volumes": []
}
```
- You can also check the AWS console to see if there are any volumes remaining.

Note: the changes only delete EBS volumes affiliated with Edamame, so if you have other volumes present in your AWS account, these will not be removed, and your output may look different.