### PR TITLE
Using secrets to inform username and pw for grafana

### DIFF
--- a/manifests/grafana.yaml
+++ b/manifests/grafana.yaml
@@ -59,6 +59,17 @@ spec:
             requests:
               cpu: 250m
               memory: 750Mi
+          env:
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: psql-secret
+                  key: psql-username
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: psql-secret
+                  key: psql-password
           volumeMounts:
             - name: grafana-pv
               mountPath: /var/lib/grafana

--- a/manifests/grafana_datasource.yaml
+++ b/manifests/grafana_datasource.yaml
@@ -4,9 +4,9 @@ datasources:
     type: postgres
     url: psql-service:5432
     database: edamame
-    user: edamame_reader
+    user: $USERNAME
     secureJsonData:
-      password:
+      password: $PASSWORD
     jsonData:
       sslmode: disable
       maxOpenConns: 0

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { init } from "./commands/init.js"
-import { destroyEKSCluster } from "./commands/destroy.js"
-import { runTest } from "./commands/runTest.js"
+import { init } from "./commands/init.js";
+import { destroyEKSCluster } from "./commands/destroy.js";
+import { runTest } from "./commands/runTest.js";
 import { getTestIds } from "./commands/getTestIds.js";
 
 const args = process.argv.slice(2);
@@ -12,7 +12,7 @@ function flagValue(flag) {
   return args[args.indexOf(flag) + 1];
 }
 
-switch(firstArg) {
+switch (firstArg) {
   case "init":
     init();
     break;
@@ -21,7 +21,7 @@ switch(firstArg) {
     //  edamame run test --file ./deployment/test.js --vus 40000
     const filePath = flagValue("--file");
     // later: add back (--name) flag to let users associate testId with name of their choice
-    //   then when want to view a test 
+    //   then when want to view a test
     runTest(filePath);
     break;
   case "get":
@@ -31,7 +31,5 @@ switch(firstArg) {
     destroyEKSCluster();
     break;
   default:
-    // placeholder
+  // placeholder
 }
-
-

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -4,7 +4,7 @@ import {
   PG_SECRET_FILE,
   GRAF_DS_FILE,
   CLUSTER_NAME,
-  GRAF_JSON_DBS
+  GRAF_JSON_DBS,
 } from "../constants/constants.js";
 import files from "./files.js";
 import fs from "fs";
@@ -17,7 +17,7 @@ const manifest = {
     k6CrData.spec.parallelism = this.parallelism(numVus);
     k6CrData.spec.script.configMap.name = testId;
     k6CrData.spec.script.configMap.file = files.parseNameFromPath(path);
-    envObjs.forEach(obj => {
+    envObjs.forEach((obj) => {
       if (obj.name === "K6_STATSD_NAMESPACE") {
         obj.value = `${testId}.`;
       }
@@ -29,18 +29,18 @@ const manifest = {
   numVus(path) {
     let numVus = 0;
 
-    if (files.exists(path)) {   
+    if (files.exists(path)) {
       let test = files.read(path);
       test = test.split("\n");
 
-      test.forEach(line => {
+      test.forEach((line) => {
         let vus = line.match("vus: [0-9]{1,}");
         let target = line.match("target: [0-9]{1,}");
 
         if (vus) {
-          numVus = this.maxNumVus(numVus, vus[0])
+          numVus = this.maxNumVus(numVus, vus[0]);
         } else if (target) {
-          numVus = this.maxNumVus(numVus, target[0])
+          numVus = this.maxNumVus(numVus, target[0]);
         }
       });
     }
@@ -61,38 +61,31 @@ const manifest = {
     return data.spec.script.configMap.name;
   },
 
-  setPgGrafCredentials(pw) {
+  setPgCredentials(pw) {
     const pgSecret = files.readYAML(PG_SECRET_FILE);
-    const grafCreds = files.readYAML(GRAF_DS_FILE);
-
-    grafCreds.datasources[0].user = `${CLUSTER_NAME}_reader`;
-    grafCreds.datasources[0].secureJsonData.password = pw;
-
     pgSecret.data["psql-username"] = this.base64(CLUSTER_NAME);
     pgSecret.data["psql-password"] = this.base64(pw);
-
     files.write(PG_SECRET_FILE, pgSecret);
-    files.write(GRAF_DS_FILE, grafCreds);
   },
 
   forEachGrafJsonDB(callback) {
     const dirPath = files.path(`/${GRAF_JSON_DBS}`);
     const names = files.fileNames(dirPath);
-    names.forEach(name => {
+    names.forEach((name) => {
       if (name.match(".json")) {
-        const nameNoExt = name.replace("\.json", "").replace("_", "-");
+        const nameNoExt = name.replace(".json", "").replace("_", "-");
         callback(nameNoExt, `${dirPath}/${name}`);
       }
     });
   },
 
   base64(value) {
-    return Buffer.from(value, 'utf8').toString('base64');
+    return Buffer.from(value, "utf8").toString("base64");
   },
 
   parallelism(numVus) {
     return Math.ceil(numVus / NUM_VUS_PER_POD);
-  }
+  },
 };
 
 export default manifest;

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -61,7 +61,7 @@ const manifest = {
     return data.spec.script.configMap.name;
   },
 
-  setPgCredentials(pw) {
+  setPgGrafCredentials(pw) {
     const pgSecret = files.readYAML(PG_SECRET_FILE);
     pgSecret.data["psql-username"] = this.base64(CLUSTER_NAME);
     pgSecret.data["psql-password"] = this.base64(pw);


### PR DESCRIPTION
When a user creates a password, we will not directly update the Grafana YAML file. I've renamed the function from `setPgGrafCredentials` to just `setPgCredentials`.

Instead, the `grafana.YAML` file will set environment variables based on our secret, and the `grafana-datasources` configmap will read from them. 