### PR TITLE
Dynamic username/password for db connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+*.env

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -6,7 +6,7 @@ generatorOptions:
 secretGenerator:
 - name: psql-secret
   envs:
-  - properties/psql.env
+  - psql.env
   type: Opaque
   options:
     disableNameSuffixHash: true

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  labels:
+    app: edamame
+secretGenerator:
+- name: psql-secret
+  envs:
+  - properties/psql.env
+  type: Opaque
+  options:
+    disableNameSuffixHash: true

--- a/manifests/postgres_secret.yaml
+++ b/manifests/postgres_secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: psql-secret
-type: Opaque
-data:
-  psql-username:
-  psql-password:

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,6 +1,6 @@
 import cluster from "../utilities/cluster.js";
 import Spinner from "../utilities/spinner.js";
-import userInput from "../utilities/userInput.js";
+import password from "../utilities/password.js";
 
 const init = async () => {
   const spinner = new Spinner("Creating Edamame cluster... (this may take up to 20 minutes)");
@@ -14,7 +14,7 @@ const init = async () => {
     await cluster.configureEBSCreds();
     spinner.succeed("Successfully configured EBS credentials.");
 
-    await userInput.processPassword()
+    await password.assign();
 
     spinner.info("Deploying Grafana, Postgres, & K6 Operator...");
     spinner.start();

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -53,9 +53,10 @@ const cluster = {
   },
 
   applyPgManifests() {
-    return kubectl
-      .applyManifest(files.path(PG_SECRET_FILE))
-      .then(() => kubectl.configMapExists(PG_CM))
+    // return kubectl
+      //.applyManifest(files.path(PG_SECRET_FILE))
+      //.then(() => 
+    return kubectl.configMapExists(PG_CM)
       .then((exists) => {
         if (!exists) {
           return kubectl.createConfigMap(files.path(PG_CM_FILE));

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -53,9 +53,6 @@ const cluster = {
   },
 
   applyPgManifests() {
-    // return kubectl
-      //.applyManifest(files.path(PG_SECRET_FILE))
-      //.then(() => 
     return kubectl.configMapExists(PG_CM)
       .then((exists) => {
         if (!exists) {
@@ -116,11 +113,6 @@ const cluster = {
   async destroy() {
     await eksctl.destroyCluster();
     return eksctl.deleteEBSVolumes();
-    /*return (
-      //kubectl.deletePv('pv', need_to_get_and_parse_name_first) 
-        //.then(() => eksctl.destroyCluster())
-        // any additional logic needed for deleting EBS?
-    );*/
   },
 };
 

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -62,7 +62,9 @@ const cluster = {
           return kubectl.createConfigMap(files.path(PG_CM_FILE));
         }
       })
-      .then(() => kubectl.applyManifest(files.path(PG_SS_FILE)));
+      .then(() => kubectl.applyManifest(files.path(PG_SS_FILE)))
+      .then(() => new Promise(res => setTimeout(res, 10000)))
+      // setting a 10s delay on return above to see if it fixes issue with timing
   },
 
   applyGrafanaManifests() {
@@ -84,7 +86,7 @@ const cluster = {
   deployServersK6Op() {
     return kubectl
       .deployK6Operator()
-      .then(() => this.applyPgManifests())
+      .then(() => this.applyPgManifests()) // added 10 s delay here
       .then(() => this.applyGrafanaManifests())
       .then(() => kubectl.applyManifest(files.path(DB_API_FILE)))
       .then(() => grafana.getExternalIp());

--- a/src/utilities/files.js
+++ b/src/utilities/files.js
@@ -8,6 +8,10 @@ const files = {
     return fs.existsSync(path);
   },
 
+  create() {
+
+  },
+
   parseNameFromPath(path) {
     const pathItems = path.split('/');
     return pathItems[pathItems.length -1];
@@ -26,9 +30,14 @@ const files = {
     return fs.readdirSync(path);
   },
 
-  write(fileName, data) {
+  writeYAML(fileName, data) {
     const filePath = this.path(fileName);
     fs.writeFileSync(filePath, yaml.dump(data));
+  },
+
+  write(fileName, data) {
+    const filePath = this.path(fileName)
+    fs.writeFileSync(filePath, data)
   },
 
   path(fileName, directory="../../manifests/") {

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -17,6 +17,10 @@ const kubectl = {
     return exec(`kubectl create configmap ${name} --from-file ${path}`);
   },
 
+  createSecret() {
+    return exec(`kubectl apply -k ${files.path("")}`);
+  },
+
   deleteManifest(path) {
     return exec(`kubectl delete -f ${path}`);
   },
@@ -63,3 +67,4 @@ const kubectl = {
 };
 
 export default kubectl;
+

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -61,7 +61,7 @@ const manifest = {
 
   setPgGrafCredentials(pw) {
     console.log(pw);
-    const secretData = `psql-username=${CLUSTER_NAME}\npsql-password=password`;
+    const secretData = `psql-username=${CLUSTER_NAME}\npsql-password=${pw}`;
     files.write("properties/psql.env", secretData); // creates or overwrites file
     return kubectl.createSecret();
   },

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -1,16 +1,14 @@
 import {
   NUM_VUS_PER_POD,
   K6_CR_FILE,
-  PG_SECRET_FILE,
-  GRAF_DS_FILE,
   CLUSTER_NAME,
   GRAF_JSON_DBS,
 } from "../constants/constants.js";
 import files from "./files.js";
-import fs from "fs";
+import kubectl from "./kubectl.js";
 
 const manifest = {
-  createK6Cr(path, numVus, testId) {
+  createK6Cr(path, numVus, testId) { // change to kustomize overlay chain
     const k6CrData = files.readYAML(K6_CR_FILE);
     const envObjs = k6CrData.spec.runner.env;
 
@@ -23,7 +21,7 @@ const manifest = {
       }
     });
 
-    files.write(K6_CR_FILE, k6CrData);
+    files.writeYAML(K6_CR_FILE, k6CrData);
   },
 
   numVus(path) {
@@ -62,10 +60,10 @@ const manifest = {
   },
 
   setPgGrafCredentials(pw) {
-    const pgSecret = files.readYAML(PG_SECRET_FILE);
-    pgSecret.data["psql-username"] = this.base64(CLUSTER_NAME);
-    pgSecret.data["psql-password"] = this.base64(pw);
-    files.write(PG_SECRET_FILE, pgSecret);
+    console.log(pw);
+    const secretData = `psql-username=${CLUSTER_NAME}\npsql-password=password`;
+    files.write("properties/psql.env", secretData); // creates or overwrites file
+    return kubectl.createSecret();
   },
 
   forEachGrafJsonDB(callback) {
@@ -89,3 +87,5 @@ const manifest = {
 };
 
 export default manifest;
+
+

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -60,7 +60,6 @@ const manifest = {
   },
 
   setPgGrafCredentials(pw) {
-    console.log(pw);
     const secretData = `psql-username=${CLUSTER_NAME}\npsql-password=${pw}`;
     files.write("properties/psql.env", secretData); // creates or overwrites file
     return kubectl.createSecret();

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -62,7 +62,7 @@ const manifest = {
   setPgGrafCredentials(pw) {
     console.log(pw);
     const secretData = `psql-username=${CLUSTER_NAME}\npsql-password=${pw}`;
-    files.write("properties/psql.env", secretData); // creates or overwrites file
+    files.write("psql.env", secretData); // creates or overwrites file
     return kubectl.createSecret();
   },
 

--- a/src/utilities/password.js
+++ b/src/utilities/password.js
@@ -1,8 +1,8 @@
 import readlineSync from "readline-sync";
 import manifest from "./manifest.js";
 
-const userInput = {
-  getPassword() {
+const password = {
+  get() {
     console.log(
       `Please enter a password to associate ` +
       `with your Edamame Grafana dashboard & ` +
@@ -14,10 +14,19 @@ const userInput = {
     return password;
   },
 
-  processPassword() {
-    const password = this.getPassword();
+  create(len) {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let result = '';
+    for (let i = 0; i < len; i++) {
+      result += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return result;
+  },
+
+  assign() {
+    const password = this.create(35);
     manifest.setPgGrafCredentials(password);
   }
 };
 
-export default userInput;
+export default password;

--- a/src/utilities/password.js
+++ b/src/utilities/password.js
@@ -1,5 +1,6 @@
 import readlineSync from "readline-sync";
 import manifest from "./manifest.js";
+import crypto from 'crypto';
 
 const password = {
   get() {
@@ -24,8 +25,8 @@ const password = {
   },
 
   assign() {
-    const password = this.create(35);
-    manifest.setPgGrafCredentials(password);
+    const password = crypto.randomUUID();
+    return manifest.setPgGrafCredentials(password);
   }
 };
 


### PR DESCRIPTION
Applies the following changes:
- Removes user input password, instead generates a random UUID upon `edamame init`.
- Creates kustomize config file to generate custom Secret for DB connection authentication
- Secret values are stored and pulled from gitignored location
- Added a 10 second timeout to ensure db container has time to start before connections are made

TODO:
- [ ] refactor 10 second timeout to use event driven paradigm (i.e. wait for "container ready" event)
- [ ] create additional kustomize configuration to dynamically apply test-id to load test yaml files