### PR TITLE
Changed the name of statsd deployment to statsite-server

### DIFF
--- a/manifests/k6_custom_resource.yaml
+++ b/manifests/k6_custom_resource.yaml
@@ -6,8 +6,8 @@ spec:
   parallelism: 1
   script:
     configMap:
-      name: '26'
-      file: test7.js
+      name: '2'
+      file: test1.js
   separate: true
   arguments: '--out distributed-statsd'
   runner:
@@ -22,7 +22,7 @@ spec:
       - name: K6_STATSD_GAUGE_NAMESPACE
         value: $(POD_NAME).
       - name: K6_STATSD_NAMESPACE
-        value: '26.'
+        value: '2.'
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/statsite_deployment.yaml
+++ b/manifests/statsite_deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: statsd-service
 spec:
   selector:
-    app: statsd
+    app: statsite-server
   ports:
     - protocol: "UDP"
       port: 8125
@@ -14,16 +14,16 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: statsd
+  name: statsite-server
 spec:
   selector:
     matchLabels:
-      app: statsd
+      app: statsite-server
   replicas: 1
   template:
     metadata:
       labels:
-        app: statsd
+        app: statsite-server
     spec:
       containers:
         - name: statsd


### PR DESCRIPTION
Changed the statsite deployment to be named statsite-server.

Note: I tried doing the same with the postgres stateful set (i.e. changing the stateful set to be called postgres-server), but I kept getting errors. I was spending too long on it (and its not super important) so I left it for now.

If someone can figure it out, feel free to add that in. 