### PR TITLE
Fix issue where init throws due to @kubernetes/client-node

### DIFF
--- a/src/commands/stopTest.js
+++ b/src/commands/stopTest.js
@@ -3,13 +3,12 @@ import cluster from "../utilities/cluster.js";
 
 import { KubeConfig, CustomObjectsApi } from '@kubernetes/client-node';
 
-const kc = new KubeConfig();
-kc.loadFromDefault();
-
-const k8sApi = kc.makeApiClient(CustomObjectsApi);
-
-
 const stopTest = async () => {
+  const kc = new KubeConfig();
+  kc.loadFromDefault();
+
+  const k8sApi = kc.makeApiClient(CustomObjectsApi);
+
   const spinner = new Spinner("Stopping current test...");
   const res = await k8sApi.listClusterCustomObject("k6.io", "v1alpha1", "k6s");
   const tests = res.body.items;


### PR DESCRIPTION
Currently `edamame init` will not run due to the the `@kubernetes/client-node` not being able to find a cluster in the `stopTest` function. Moved a few lines so this doesn't occur.