### PR TITLE
Allows dynamic values for K6 CRD.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 *.env
+manifests/load_test_crds/*

--- a/manifests/k6_custom_resource_template.yaml
+++ b/manifests/k6_custom_resource_template.yaml
@@ -3,11 +3,11 @@ kind: K6
 metadata:
   name: k6-edamame-test
 spec:
-  parallelism: 1
+  parallelism: 1             # default value
   script:
     configMap:
-      name: '2'
-      file: test1.js
+      name: '1'              # default value
+      file: test.js          # default value
   separate: true
   arguments: '--out distributed-statsd'
   runner:
@@ -22,7 +22,7 @@ spec:
       - name: K6_STATSD_GAUGE_NAMESPACE
         value: $(POD_NAME).
       - name: K6_STATSD_NAMESPACE
-        value: '2.'
+        value: '1.'          # default value
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -10,7 +10,8 @@ const GRAF_DB_FILE = "grafana_dashboards.yaml";
 const GRAF_DS = "grafana-datasources";
 const GRAF_DBS = "grafana-dashboards";
 const GRAF_JSON_DBS = "grafana_json_dbs";
-const K6_CR_FILE = "k6_custom_resource.yaml";
+const K6_CR_TEMPLATE = "k6_custom_resource_template.yaml"
+const K6_CR_FILE = 'load_test_crds/k6_crd.yaml';
 const PG_SECRET_FILE = "postgres_secret.yaml";
 const PG_CM = "psql-configmap";
 const PG_CM_FILE = "postgres_configmap.yaml";
@@ -37,6 +38,7 @@ export {
   GRAF_JSON_DBS,
   DB_API_PORT,
   DB_API_NAME,
+  K6_CR_TEMPLATE,
   K6_CR_FILE,
   PG_SECRET_FILE,
   PG_CM_FILE,

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -95,6 +95,7 @@ const cluster = {
       .then(() => kubectl.deleteManifest(files.path(STATSITE_FILE)))
       .then(() => kubectl.deleteConfigMap(testId))
       .then(() => eksctl.scaleLoadGenNodes(0))
+      .then(() => files.delete(K6_CR_FILE));
   },
 
   launchK6Test(testPath, numVus) {

--- a/src/utilities/files.js
+++ b/src/utilities/files.js
@@ -8,8 +8,8 @@ const files = {
     return fs.existsSync(path);
   },
 
-  create() {
-
+  makeDir(dirName) {
+    return fs.mkdir(this.path(dirName), (err) => err)
   },
 
   parseNameFromPath(path) {
@@ -47,6 +47,10 @@ const files = {
     let fullpath = path.join(dirname, desiredPathEnd);
     return fullpath.replace(/ /g, '\\ ');
   },
+
+  delete(fileName) {
+    return fs.rm(this.path(fileName), (err) => err)
+  }
 
 };
 

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -1,5 +1,7 @@
+import { exists } from "fs";
 import {
   NUM_VUS_PER_POD,
+  K6_CR_TEMPLATE,
   K6_CR_FILE,
   CLUSTER_NAME,
   GRAF_JSON_DBS,
@@ -9,7 +11,7 @@ import kubectl from "./kubectl.js";
 
 const manifest = {
   createK6Cr(path, numVus, testId) { // change to kustomize overlay chain
-    const k6CrData = files.readYAML(K6_CR_FILE);
+    const k6CrData = files.readYAML(K6_CR_TEMPLATE);
     const envObjs = k6CrData.spec.runner.env;
 
     k6CrData.spec.parallelism = this.parallelism(numVus);
@@ -20,6 +22,10 @@ const manifest = {
         obj.value = `${testId}.`;
       }
     });
+
+    if (!files.exists(files.path('/load_test_crds'))) {
+      files.makeDir('/load_test_crds')
+    }
 
     files.writeYAML(K6_CR_FILE, k6CrData);
   },
@@ -86,5 +92,3 @@ const manifest = {
 };
 
 export default manifest;
-
-


### PR DESCRIPTION
- Changes the original yaml file to a "template"
- Reads in yaml data from template
- Changes fields to dynamic values where required (parallelism, test id)
- Writes new yaml data to a newly created file
- Applies the newly created file to the cluster to run the test
- Deletes the file when complete
- Folder where file is kept is added to .gitignore to avoid accidental commits

Resolves #75 