### PR TITLE
added functions to kubectl to check for port forward processes, start…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Password for PG & Grafana has been set as:
 
 **Notes**:
 
-- It can as long as *20 minutes* to create the cluster and apply the necessary permissions.
+- It can as long as _20 minutes_ to create the cluster and apply the necessary permissions.
 - To access the Grafana dashboards, use the provided link. For now, the default Grafana username and password are used (`admin` and `admin`). In Grafana, navigate to the Dashboards, and select the `testid` for the data you wish to view. If no tests have been run, you may see an error, until there are test ids in the database to display.
 
 ### edamame run
@@ -89,6 +89,21 @@ Outputs:
 
 **Note**: In the future, the availability of this command and the format of the return value may change. We'd like to have tests identifiable by some user-specified custom name.
 
+### edamame grafana
+
+Usage: `edamame grafana`
+Outputs:
+
+```
+[02:33:01:842] ℹ Configuring local access to grafana dashboard...
+[07:31:34:711] ✔ Please find your Grafana dashboard at: http://localhost:3000
+
+```
+
+- Provides local access to the grafana dashboard.
+
+**Note**: If you enter `CTRL+C` in the terminal after running edamame grafana, that will end your local access to the dashboard. To run a test while maintaining access to the grafana dashboard, please open a new terminal and execute `edamame run --file {/path/to/test.js}`
+
 ### edamame teardown
 
 Usage: `edamame teardown`
@@ -105,6 +120,6 @@ Outputs:
 
 **Notes**:
 
-- Because this command will delete the entire cluster, it will also *delete all data*. In order to maintain historical data, the cluster must remain up. In the future, we will be providing an additional command to export data, so that it is not lost when the cluster is deleted.
+- Because this command will delete the entire cluster, it will also _delete all data_. In order to maintain historical data, the cluster must remain up. In the future, we will be providing an additional command to export data, so that it is not lost when the cluster is deleted.
 - The process of deleting a cluster can take 10-15 mins.
 - If you try to create a new cluster directly after deleting a cluster, you may run into errors. This is because AWS continues to remove resources associated with the EKS cluster for up to 10 minutes after the command completes. Try waiting for a little while, and seeing if that fixes the problem.

--- a/k6_tests/test8.js
+++ b/k6_tests/test8.js
@@ -1,0 +1,21 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+      duration: '60s',
+      rate: 1000,
+      timeUnit: '1s',
+      preAllocatedVUs: 3000,
+      maxVUs: 3000,
+    },
+  },
+};
+
+export default function () {
+  http.get('https://test.k6.io/contacts.php');
+  sleep(0.5);
+}

--- a/manifests/db_api_deployment.yaml
+++ b/manifests/db_api_deployment.yaml
@@ -47,17 +47,3 @@ spec:
                 secretKeyRef:
                   name: psql-secret
                   key: psql-password
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: db-api-service
-spec:
-  selector:
-    app: db-api
-  type: LoadBalancer
-  ports:
-    - protocol: TCP
-      port: 4444
-      targetPort: 4444
-      nodePort: 30000

--- a/manifests/grafana.yaml
+++ b/manifests/grafana.yaml
@@ -92,17 +92,3 @@ spec:
         - name: http-dashboard-volume
           configMap:
             name: http-dashboard
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: grafana
-spec:
-  ports:
-    - port: 3000
-      protocol: TCP
-      targetPort: http-grafana
-  selector:
-    app: grafana
-  sessionAffinity: None
-  type: LoadBalancer

--- a/src/commands/getTestIds.js
+++ b/src/commands/getTestIds.js
@@ -5,9 +5,9 @@ const getTestIds = (testPath, numVus) => {
   const spinner = new Spinner("Retrieving all test ids...");
   dbApi
     .getTestIds()
-    .then(({ stdout }) => {
+    .then(ids => {
       spinner.succeed();
-      console.log(stdout);
+      console.log(ids);
     })
     .catch((err) => {
       spinner.fail(`Error running test: ${err}`);

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -15,11 +15,11 @@ const init = async () => {
     spinner.succeed("Successfully configured EBS credentials.");
 
     await password.assign();
-
+    
     spinner.info("Deploying Grafana, Postgres, & K6 Operator...");
     spinner.start();
+    
     const grafanaUrl = await cluster.deployServersK6Op();
-    spinner.info(`Please find your Grafana dashboard at: ${grafanaUrl}`);
     spinner.succeed("Cluster configured. Welcome to Edamame!");
   } catch (err) {
     spinner.fail(`Error creating cluster: ${err}`);

--- a/src/commands/portForwardGrafana.js
+++ b/src/commands/portForwardGrafana.js
@@ -1,12 +1,15 @@
 import Spinner from "../utilities/spinner.js";
 import grafana from "../utilities/grafana.js";
+import { GRAF_PORT } from "../constants/constants.js";
 
 const portForwardGrafana = () => {
   const spinner = new Spinner("Configuring local access to grafana dashboard...");
   grafana
     .getLocalAddressWhenReady()
-    .then(url => {
-      spinner.succeed(`Please find your Grafana dashboard at: ${url}`);
+    .then(message => {
+      message.match(`because port ${GRAF_PORT}`) ? 
+        spinner.fail(message) :
+        spinner.succeed(`Please find your Grafana dashboard at: ${message}`);
     })
     .catch((err) => {
       spinner.fail(`Error running test: ${err}`);

--- a/src/commands/portForwardGrafana.js
+++ b/src/commands/portForwardGrafana.js
@@ -1,0 +1,16 @@
+import Spinner from "../utilities/spinner.js";
+import grafana from "../utilities/grafana.js";
+
+const portForwardGrafana = () => {
+  const spinner = new Spinner("Configuring local access to grafana dashboard...");
+  grafana
+    .getLocalAddressWhenReady()
+    .then(url => {
+      spinner.succeed(`Please find your Grafana dashboard at: ${url}`);
+    })
+    .catch((err) => {
+      spinner.fail(`Error running test: ${err}`);
+    });
+};
+
+export { portForwardGrafana };

--- a/src/commands/runTest.js
+++ b/src/commands/runTest.js
@@ -1,4 +1,3 @@
-import files from "../utilities/files.js";
 import loadGenerators from "../utilities/loadGenerators.js";
 import Spinner from "../utilities/spinner.js";
 import cluster from "../utilities/cluster.js";
@@ -14,8 +13,8 @@ const runTest = async (testPath) => {
     }
     spinner.succeed(`Successfully read test script.`);
 
-
-    spinner.info(`Initializing load test with ${numVus}...`);
+    const nodeCount = manifest.parallelism(numVus);
+    spinner.info(`Initializing load test with ${nodeCount} ${nodeCount === 1 ? "node" : "nodes"}...`);
     spinner.start();
     await cluster.launchK6Test(testPath, numVus);
     spinner.succeed("Successfully initialized load test.");

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -3,7 +3,6 @@ const POLL_FREQUENCY = 30000;
 const DB_API_PORT = 4444;
 const GRAF_PORT = 3000;
 const PORT_FORWARD_DELAY = 5000;
-const DB_API_SERVICE = "service/db-api-service";
 const GRAF = "grafana.yaml";
 const GRAF_DS_FILE = "grafana_datasource.yaml";
 const GRAF_DB_FILE = "grafana_dashboards.yaml";
@@ -36,7 +35,6 @@ export {
   GRAF_DB_FILE,
   GRAF_JSON_DBS,
   DB_API_PORT,
-  DB_API_SERVICE,
   K6_CR_FILE,
   PG_SECRET_FILE,
   PG_CM_FILE,

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -2,8 +2,8 @@ const NUM_VUS_PER_POD = 1000;
 const POLL_FREQUENCY = 30000;
 const DB_API_PORT = 4444;
 const GRAF_PORT = 3000;
-const DB_API_NAME = "db-api-service";
-const EXTERNAL_IP_REGEX = "amazonaws.com";
+const PORT_FORWARD_DELAY = 5000;
+const DB_API_SERVICE = "service/db-api-service";
 const GRAF = "grafana.yaml";
 const GRAF_DS_FILE = "grafana_datasource.yaml";
 const GRAF_DB_FILE = "grafana_dashboards.yaml";
@@ -26,7 +26,7 @@ const EBS_CSI_DRIVER_REGEX =
 export {
   NUM_VUS_PER_POD,
   POLL_FREQUENCY,
-  EXTERNAL_IP_REGEX,
+  PORT_FORWARD_DELAY,
   PG_CM,
   GRAF,
   GRAF_DS,
@@ -36,7 +36,7 @@ export {
   GRAF_DB_FILE,
   GRAF_JSON_DBS,
   DB_API_PORT,
-  DB_API_NAME,
+  DB_API_SERVICE,
   K6_CR_FILE,
   PG_SECRET_FILE,
   PG_CM_FILE,

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { init } from "./commands/init.js";
 import { destroyEKSCluster } from "./commands/destroy.js";
 import { runTest } from "./commands/runTest.js";
 import { getTestIds } from "./commands/getTestIds.js";
+import { portForwardGrafana } from "./commands/portForwardGrafana.js";
 import { Command } from "commander";
 const program = new Command();
 
@@ -28,6 +29,13 @@ program
   .description("get a list of all available test IDs")
   .action(() => {
     getTestIds();
+  });
+
+program
+  .command("grafana")
+  .description("configure local access to grafana dashboard to analyze test metrics")
+  .action(() => {
+    portForwardGrafana();
   });
 
 program

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -86,7 +86,6 @@ const cluster = {
       .then(() => this.applyPgManifests()) // added 10 s delay here
       .then(() => this.applyGrafanaManifests())
       .then(() => kubectl.applyManifest(files.path(DB_API_FILE)))
-      .then(() => grafana.getExternalIp());
   },
 
   phaseOutK6() {
@@ -106,10 +105,10 @@ const cluster = {
         return kubectl.createConfigMapWithName(testId, testPath);
       })
       .then(() => kubectl.applyManifest(files.path(STATSITE_FILE)))
+      .then(() => kubectl.applyManifest(files.path(K6_CR_FILE)))
       .then(() => eksctl.scaleLoadGenNodes(manifest.parallelism(numVus)))
-      .then(() => kubectl.applyManifest(files.path(K6_CR_FILE)));
   },
-
+  
   async destroy() {
     await eksctl.destroyCluster();
     return eksctl.deleteEBSVolumes();

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -1,7 +1,7 @@
 import { 
-  DB_API_NAME,
+  DB_API_SERVICE,
   DB_API_PORT,
-  EXTERNAL_IP_REGEX
+  PORT_FORWARD_DELAY
  } from "../constants/constants.js";
 import kubectl from "./kubectl.js";
 import { promisify } from "util";
@@ -10,52 +10,49 @@ const exec = promisify(child_process.exec);
 
 const dbApi = {
   newTestId() {
-    return (
-      kubectl.getIps()
-        .then(({stdout}) => {
-          const url = this.findUrl(stdout);
-          return exec(`curl -X POST ${url}/tests`);
-        })
-        .then(({stdout}) => {
-          const testId = stdout.match('[0-9]{1,}');
-          if (testId) {
-            return testId[0];
-          }
-        })
-    );
+    kubectl
+      .exactPodName("db-api")
+      .then(podName => {
+        kubectl.tempPortForward(podName, DB_API_PORT, DB_API_PORT);
+      });
+      
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        this.curlRequest("-X POST")
+          .then(({stdout}) => {
+            kubectl.endPortForward("db-api");
+            const testId = stdout.match('[0-9]{1,}');
+            if (testId) {
+              resolve(testId[0]);
+            }
+          })
+      }, PORT_FORWARD_DELAY)
+    });
   },
 
-  findUrl(stdout) {
-    let url;
-    const services = stdout.split("\n");
-
-    for (let colIdx = 0; colIdx < services.length; colIdx++) {
-      const serviceCols = services[colIdx];
-
-      if (serviceCols.match(DB_API_NAME)) {
-        const propRows = serviceCols.split(" ");
-
-        for (let rowIdx = 0; rowIdx < propRows.length; rowIdx++) {
-          const prop = propRows[rowIdx];
-          if (prop && prop.match(EXTERNAL_IP_REGEX)) {
-            return  prop + ":" + DB_API_PORT;
-          }
-        }
-      }
-    }
+  curlRequest(http_method="", path="tests") {
+    return exec(`curl ${http_method} http://localhost:${DB_API_PORT}/${path}`);
   },
 
   getTestIds() {
-    return (
-      kubectl.getIps()
-        .then(({stdout}) => {
-          const url = this.findUrl(stdout);
-          return exec(`curl -X GET ${url}/tests`);
-        })
-    );
+    kubectl
+      .exactPodName("db-api")
+      .then(podName => {
+        kubectl.tempPortForward(podName, DB_API_PORT, DB_API_PORT);
+      });
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        return (
+          this.curlRequest("")
+            .then(({stdout}) => {
+              kubectl.endPortForward("db-api");
+              resolve(stdout);
+            })
+        );
+      }, PORT_FORWARD_DELAY)
+    });
   }
 };
 
 export default dbApi;
-
-

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -1,5 +1,4 @@
 import { 
-  DB_API_SERVICE,
   DB_API_PORT,
   PORT_FORWARD_DELAY
  } from "../constants/constants.js";

--- a/src/utilities/grafana.js
+++ b/src/utilities/grafana.js
@@ -1,47 +1,42 @@
 import kubectl from "./kubectl.js";
 import { 
   POLL_FREQUENCY,
-  EXTERNAL_IP_REGEX,
   GRAF_PORT
 } from "../constants/constants.js";
 
 const grafana = {
-  checkIpAvailable() {
-    return (
-      kubectl.getIps()
-        .then(({stdout}) => {
-          const services = stdout.split("\n");
-
-          for (let colIdx = 0; colIdx < services.length; colIdx++) {
-            const serviceCols = services[colIdx];
-      
-            if (serviceCols.match("grafana")) {
-              const propRows = serviceCols.split(" ");
-      
-              for (let rowIdx = 0; rowIdx < propRows.length; rowIdx++) {
-                const prop = propRows[rowIdx];
-                if (prop && prop.match(EXTERNAL_IP_REGEX)) {
-                  return `${prop}:${GRAF_PORT}`;
-                }
-              }
-            }
-          }
-        })
-    );
-  },
-
-  getExternalIp() {
+  getLocalAddressWhenReady() {
     return new Promise((resolve, reject) => {
       const interval = setInterval(async () => {
-        const url = await this.checkIpAvailable();
-        if (!url) {
+        const available = await kubectl.checkPodAvailable("grafana");
+        if (!available) {
           return;
         }
-
         clearInterval(interval);
-        resolve(url);
+
+        kubectl
+          .exactPodName("grafana")
+          .then(podName => {
+            kubectl.tempPortForward(podName, GRAF_PORT, GRAF_PORT)
+          });
+        
+        resolve(`http://localhost:${GRAF_PORT}`);
       }, POLL_FREQUENCY);
     });
+  },
+
+  detailedUrl(testId) {
+    kubectl
+      .exactPodName("grafana")
+      .then(podName => {
+        kubectl.tempPortForward(podName, GRAF_PORT, GRAF_PORT);
+      });
+  
+    return (
+      `http://localhost:${GRAF_PORT}/d/IWSghv-4k/` +
+      `http-data?orgId=1&var-testid=${testId}` +
+      `&refresh=5s&from=now-15m&to=now`
+    );
   }
 };
 

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -55,13 +55,17 @@ const kubectl = {
     );
   },
 
+  localPortAlreadyBound(port) {
+    return exec(`lsof -iTCP:${port} -sTCP:LISTEN`);
+  },
+
   tempPortForward(podName, localAccessPort, podPort) {
     this.pidPortForward(podName)
       .then(pid => {
         if (!pid) {
           return exec(`kubectl port-forward ${podName} ${localAccessPort}:${podPort} &`);
         }
-      })
+      });
   }, 
 
   checkPodAvailable(podNameRegex) {

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -29,6 +29,73 @@ const kubectl = {
     return exec(`kubectl get svc`);
   },
 
+  pidPortForward(name) {
+    return (
+      exec(`ps aux | grep -i ${name} | grep -v grep | awk {'print $2'}`)
+        .then(({stdout}) => {
+          return stdout;
+        })
+    );
+  },
+
+  exactPodName(abbreviatedName) {
+    return (
+      this.getPods()
+        .then(({stdout}) => {
+          const pods = stdout.split("\n");
+
+          for (let i = 0; i < pods.length; i++) {
+            const pod = pods[i];
+            if (pod.match(abbreviatedName)) {
+              const podDetails = pod.split(" ");
+              return podDetails[0];
+            }
+          }
+        })
+    );
+  },
+
+  tempPortForward(podName, localAccessPort, podPort) {
+    this.pidPortForward(podName)
+      .then(pid => {
+        if (!pid) {
+          return exec(`kubectl port-forward ${podName} ${localAccessPort}:${podPort} &`);
+        }
+      })
+  }, 
+
+  checkPodAvailable(podNameRegex) {
+    return (
+      this.getPods()
+        .then(({stdout}) => {
+          const pods = stdout.split("\n");
+
+          for (let rowIdx = 0; rowIdx < pods.length; rowIdx++) {
+            const pod = pods[rowIdx];
+
+            if (pod.match(podNameRegex)) {
+              const podDetails = pod.split(" ");
+      
+              for (let colIdx = 0; colIdx < podDetails.length; colIdx++) {
+                const detail = podDetails[colIdx];
+                if (detail && detail.match('Running')) {
+                  return true;
+                }
+              }
+            }
+          }
+        })
+    );
+  },
+
+  endPortForward(name) {
+    return (
+      this.pidPortForward(name)
+      .then(pid => exec(`kill ${pid}`))
+    );
+  },
+
+
   configMapExists(name) {
     return (
       exec(`kubectl get configmaps`)
@@ -37,10 +104,6 @@ const kubectl = {
         })
     );
   },
-
-  portForward(service, port1, port2) {
-    return exec(`kubectl port-forward ${service} ${port1}:${port2} & `);
-  }, 
 
   createConfigMap(path) {
     // added this b/c psql-host key wasn't being properly registered by db api

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -34,11 +34,14 @@ const manifest = {
       test.forEach((line) => {
         let vus = line.match("vus: [0-9]{1,}");
         let target = line.match("target: [0-9]{1,}");
+        let max = line.match("maxVUs: [0-9]{1,}");
 
         if (vus) {
           numVus = this.maxNumVus(numVus, vus[0]);
         } else if (target) {
           numVus = this.maxNumVus(numVus, target[0]);
+        } else if (max) {
+          numVus = this.maxNumVus(numVus, max[0]);
         }
       });
     }

--- a/src/utilities/password.js
+++ b/src/utilities/password.js
@@ -3,18 +3,6 @@ import manifest from "./manifest.js";
 import crypto from 'crypto';
 
 const password = {
-  get() {
-    console.log(
-      `Please enter a password to associate ` +
-      `with your Edamame Grafana dashboard & ` +
-      `Postgres database account.`
-    );
-    const password = readlineSync.question("Password: ");
-    console.log("Password for PG & Grafana has been set as:");
-    console.log(password);
-    return password;
-  },
-
   create(len) {
     const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     let result = '';


### PR DESCRIPTION
… port forwarding, and end port forwarding where necessary
- updated all the functions in dbApi to use port forwarding
- added edamame grafana command to allow for local access to grafana dashboard via port forwarding
- updated readme for edamame grafana command
- removed grafana and dp-api services from their respective manifest yaml files, because we no longer need their external ips
- updated manifest.js to check for maxVUs when parsing the test script
- added test8.js and tested that the updates to the regex in manifest.js were working

This is to address #28 and #72

Resolves #28 and #72