### PR TITLE
Update statsite to allow custom configs; performance tune for 1 million metrics per second

### DIFF
--- a/manifests/k6_custom_resource_template.yaml
+++ b/manifests/k6_custom_resource_template.yaml
@@ -23,6 +23,10 @@ spec:
         value: $(POD_NAME).
       - name: K6_STATSD_NAMESPACE
         value: '1.'          # default value
+      - name: K6_STATSD_BUFFER_SIZE
+        value: '20'
+      - name: K6_STATSD_PUSH_INTERVAL
+        value: '0.5s'
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/statsite-config/statsite.conf
+++ b/manifests/statsite-config/statsite.conf
@@ -1,0 +1,10 @@
+[statsite]
+  port = 8125
+  udp_port = 8125
+  log_level = DEBUG
+  flush_interval = 1
+  timer_eps = 0.01
+  timers_include = count
+  quantiles = 0.9,0.95,0.99
+  aligned_flush = 1
+  stream_cmd = node /usr/local/share/statsite/sinks/postgres.js

--- a/manifests/statsite_deployment.yaml
+++ b/manifests/statsite_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: statsd
-          image: lukeoguro/custom-statsite:latest
+          image: lukeoguro/custom-statsite:2.0
           ports:
             - name: statsd
               containerPort: 8125
@@ -57,3 +57,19 @@ spec:
                 secretKeyRef:
                   name: psql-secret
                   key: psql-password
+          volumeMounts:
+          - name: config
+            mountPath: /etc/statsite
+      volumes:
+        - name: config
+          configMap:
+            name: statsite-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: alpha.eksctl.io/nodegroup-name
+                    operator: In
+                    values:
+                      - statsite

--- a/manifests/statsite_nodegroup_template.yaml
+++ b/manifests/statsite_nodegroup_template.yaml
@@ -1,0 +1,16 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: edamame
+  region: us-east-1 # default value
+
+managedNodeGroups:
+  - name: statsite
+    instanceType: m5zn.xlarge
+    desiredCapacity: 0
+    minSize: 0
+    maxSize: 1
+    preBootstrapCommands:
+      - sysctl -w net.core.rmem_default=134217728 # Set to 128M; 52428800 not tested; 200M tested (209715200)
+      - sysctl -w net.core.rmem_max=134217728 # Set to 128M

--- a/manifests/statsite_nodegroup_template.yaml
+++ b/manifests/statsite_nodegroup_template.yaml
@@ -7,7 +7,7 @@ metadata:
 
 managedNodeGroups:
   - name: statsite
-    instanceType: m5zn.xlarge
+    instanceType: m5.xlarge
     desiredCapacity: 0
     minSize: 0
     maxSize: 1

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,4 +1,4 @@
-const NUM_VUS_PER_POD = 1000;
+const NUM_VUS_PER_POD = 5000;
 const POLL_FREQUENCY = 30000;
 const DB_API_PORT = 4444;
 const GRAF_PORT = 3000;
@@ -18,6 +18,11 @@ const PG_CM = "psql-configmap";
 const PG_CM_FILE = "postgres_configmap.yaml";
 const PG_SS_FILE = "postgres_statefulset.yaml";
 const STATSITE_FILE = "statsite_deployment.yaml";
+const STATSITE_NODE_GRP = "statsite";
+const STATSITE_NODE_GRP_TEMPLATE = "statsite_nodegroup_template.yaml";
+const STATSITE_NODE_GRP_FILE = "load_test_crds/statsite_nodegroup.yaml";
+const STATSITE_CM = "statsite-config";
+const STATSITE_CM_FOLDER = "statsite-config";
 const DB_API_FILE = "db_api_deployment.yaml";
 const CLUSTER_NAME = "edamame";
 const LOAD_GEN_NODE_GRP = "load-generators";
@@ -46,6 +51,11 @@ export {
   PG_CM_FILE,
   PG_SS_FILE,
   STATSITE_FILE,
+  STATSITE_NODE_GRP_TEMPLATE,
+  STATSITE_NODE_GRP,
+  STATSITE_CM,
+  STATSITE_CM_FOLDER,
+  STATSITE_NODE_GRP_FILE,
   DB_API_FILE,
   CLUSTER_NAME,
   LOAD_GEN_NODE_GRP,

--- a/src/utilities/eksctl.js
+++ b/src/utilities/eksctl.js
@@ -1,6 +1,13 @@
 import { promisify } from "util";
 import child_process from "child_process";
-import { CLUSTER_NAME, LOAD_GEN_NODE_GRP } from "../constants/constants.js";
+import {
+  CLUSTER_NAME,
+  LOAD_GEN_NODE_GRP,
+  STATSITE_NODE_GRP,
+  STATSITE_NODE_GRP_TEMPLATE,
+  STATSITE_NODE_GRP_FILE
+} from "../constants/constants.js";
+import files from '../utilities/files.js';
 const exec = promisify(child_process.exec);
 
 const eksctl = {
@@ -15,8 +22,23 @@ const eksctl = {
   createLoadGenGrp() {
     return exec(
       `eksctl create nodegroup --cluster=${CLUSTER_NAME} ` +
-        `--name=${LOAD_GEN_NODE_GRP} --node-type=m5.large ` +
-        `--nodes=0 --nodes-min=0 --nodes-max=100 `
+      `--name=${LOAD_GEN_NODE_GRP} --node-type=m5.large ` +
+      `--nodes=0 --nodes-min=0 --nodes-max=100 `
+    );
+  },
+
+  async createStatsiteGrp() {
+    const nodeGrpData = files.readYAML(STATSITE_NODE_GRP_TEMPLATE);
+    nodeGrpData.metadata.region = await this.getRegion();
+
+    if (!files.exists(files.path('/load_test_crds'))) {
+      files.makeDir('/load_test_crds')
+    }
+
+    files.writeYAML(STATSITE_NODE_GRP_FILE, nodeGrpData);
+
+    return exec(
+      `eksctl create nodegroup --config-file ${files.path(STATSITE_NODE_GRP_FILE)}`
     );
   },
 
@@ -27,20 +49,20 @@ const eksctl = {
   createOIDC() {
     return exec(
       "eksctl utils associate-iam-oidc-provider " +
-        `--cluster ${CLUSTER_NAME} --approve`
+      `--cluster ${CLUSTER_NAME} --approve`
     );
   },
 
   addIAMDriverRole() {
     return exec(
       "eksctl create iamserviceaccount " +
-        "--name ebs-csi-controller-sa " +
-        "--namespace kube-system " +
-        `--cluster ${CLUSTER_NAME} ` +
-        "--attach-policy-arn " +
-        "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy " +
-        "--approve --role-only " +
-        "--role-name AmazonEKS_EBS_CSI_DriverRole"
+      "--name ebs-csi-controller-sa " +
+      "--namespace kube-system " +
+      `--cluster ${CLUSTER_NAME} ` +
+      "--attach-policy-arn " +
+      "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy " +
+      "--approve --role-only " +
+      "--role-name AmazonEKS_EBS_CSI_DriverRole"
     );
   },
 
@@ -59,21 +81,34 @@ const eksctl = {
   addCsiDriver(roleArn) {
     return exec(
       "eksctl create addon " +
-        "--name aws-ebs-csi-driver " +
-        `--cluster ${CLUSTER_NAME} ` +
-        `--service-account-role-arn ${roleArn} --force`
+      "--name aws-ebs-csi-driver " +
+      `--cluster ${CLUSTER_NAME} ` +
+      `--service-account-role-arn ${roleArn} --force`
     );
   },
 
   scaleLoadGenNodes(numNodes) {
     return exec(
       `eksctl scale nodegroup --cluster=${CLUSTER_NAME} ` +
-        `--nodes=${numNodes} ${LOAD_GEN_NODE_GRP}`
+      `--nodes=${numNodes} ${LOAD_GEN_NODE_GRP}`
     );
+  },
+
+  scaleStatsiteNodes(numNodes) {
+    return exec(
+      `eksctl scale nodegroup --cluster=${CLUSTER_NAME} ` +
+      `--nodes=${numNodes} ${STATSITE_NODE_GRP}`
+    )
   },
 
   destroyCluster() {
     return exec(`eksctl delete cluster --name ${CLUSTER_NAME}`);
+  },
+
+  async getRegion() {
+    const { stdout } = await exec(`eksctl get cluster --verbose 0`);
+    const line = stdout.split("\n").find(line => line.includes("edamame"));
+    return line.split("\t")[1];
   },
 
   async deleteEBSVolumes() {


### PR DESCRIPTION
Main changes:
- Updates statsite image so that it takes a custom `statsite.conf` file
- Create a new managed node group for statsite which has kernel-level changes to handle high UDP traffic

Resolves #98. Linking to #36, but I won't resolve this until I do a bit more testing later this week.