### PR TITLE
Vus per pod

### DIFF
--- a/manifests/k6_custom_resource_template.yaml
+++ b/manifests/k6_custom_resource_template.yaml
@@ -24,7 +24,7 @@ spec:
       - name: K6_STATSD_NAMESPACE
         value: '1.'          # default value
       - name: K6_STATSD_BUFFER_SIZE
-        value: '20'
+        value: '1432'
       - name: K6_STATSD_PUSH_INTERVAL
         value: '0.5s'
     affinity:

--- a/manifests/statsite-config/statsite.conf
+++ b/manifests/statsite-config/statsite.conf
@@ -2,7 +2,7 @@
   port = 8125
   udp_port = 8125
   log_level = DEBUG
-  flush_interval = 1
+  flush_interval = 5
   timer_eps = 0.01
   timers_include = count
   quantiles = 0.9,0.95,0.99

--- a/manifests/statsite_nodegroup_template.yaml
+++ b/manifests/statsite_nodegroup_template.yaml
@@ -7,10 +7,10 @@ metadata:
 
 managedNodeGroups:
   - name: statsite
-    instanceType: m5.xlarge
+    instanceType: m5zn.xlarge
     desiredCapacity: 0
     minSize: 0
     maxSize: 1
     preBootstrapCommands:
-      - sysctl -w net.core.rmem_default=134217728 # Set to 128M; 52428800 not tested; 200M tested (209715200)
-      - sysctl -w net.core.rmem_max=134217728 # Set to 128M
+      - sysctl -w net.core.rmem_default=536870912 # Set to 512M
+      - sysctl -w net.core.rmem_max=536870912 # Set to 512M

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { updateTestName } from "./commands/updateTestName.js";
 import { deleteTest } from "./commands/deleteTest.js";
 import { portForwardGrafana } from "./commands/portForwardGrafana.js";
 import { stopTest } from "./commands/stopTest.js"
+import { NUM_VUS_PER_POD } from "./constants/constants.js";
 import { Command } from "commander";
 const program = new Command();
 
@@ -22,8 +23,9 @@ program
 
 program
   .command("run")
-  .requiredOption('-p, --path <path>', 'Relative filepath to k6 load test script')
+  .requiredOption('-f, --file <file>', 'File path of k6 load test script')
   .option('-n, --name <name>', 'Name to associate with test')
+  .option('-v, --vus-per-pod <vus>', 'Specify the number of VUs per pod', NUM_VUS_PER_POD)
   .description("run the load test")
   .action(runTest);
 

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -112,15 +112,15 @@ const cluster = {
       .then(() => files.delete(K6_CR_FILE));
   },
 
-  launchK6Test(testPath, name, numVus, testId) {
-    manifest.createK6Cr(testPath, numVus, testId);
+  launchK6Test(testPath, testId, numNodes) {
+    manifest.createK6Cr(testPath, testId, numNodes);
 
     return (
       kubectl.createConfigMapWithName(testId, testPath)
         .then(() => kubectl.applyManifest(files.path(STATSITE_FILE)))
         .then(() => kubectl.applyManifest(files.path(K6_CR_FILE)))
         .then(() => eksctl.scaleStatsiteNodes(1))
-        .then(() => eksctl.scaleLoadGenNodes(manifest.parallelism(numVus)))
+        .then(() => eksctl.scaleLoadGenNodes(numNodes))
     );
   },
 

--- a/src/utilities/loadGenerators.js
+++ b/src/utilities/loadGenerators.js
@@ -33,12 +33,11 @@ const loadGenerators = {
     );
   },
 
-  pollUntilAllComplete(numVus) {
-    const numLoadGenerators = manifest.parallelism(numVus);
+  pollUntilAllComplete(numNodes) {
     return new Promise((resolve, reject) => {
       const interval = setInterval(async () => {
 
-        const finished = await this.checkAllCompleted(numLoadGenerators);
+        const finished = await this.checkAllCompleted(numNodes);
         if (!finished) {
           return;
         }

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -1,6 +1,5 @@
 import { exists } from "fs";
 import {
-  NUM_VUS_PER_POD,
   K6_CR_TEMPLATE,
   K6_CR_FILE,
   CLUSTER_NAME,
@@ -10,11 +9,11 @@ import files from "./files.js";
 import kubectl from "./kubectl.js";
 
 const manifest = {
-  createK6Cr(path, numVus, testId) { // change to kustomize overlay chain
+  createK6Cr(path, testId, numNodes) { // change to kustomize overlay chain
     const k6CrData = files.readYAML(K6_CR_TEMPLATE);
     const envObjs = k6CrData.spec.runner.env;
 
-    k6CrData.spec.parallelism = this.parallelism(numVus);
+    k6CrData.spec.parallelism = numNodes;
     k6CrData.spec.script.configMap.name = String(testId);
     k6CrData.spec.script.configMap.file = files.parseNameFromPath(path);
     envObjs.forEach((obj) => {
@@ -89,8 +88,8 @@ const manifest = {
     return Buffer.from(value, "utf8").toString("base64");
   },
 
-  parallelism(numVus) {
-    return Math.ceil(numVus / NUM_VUS_PER_POD);
+  parallelism(numVus, vusPerPod) {
+    return Math.ceil(numVus / vusPerPod);
   },
 };
 


### PR DESCRIPTION
This ended up being a bit of an overloaded PR, but the main change is to:
- Change the `--path` flag to `--file` for `edamame run` so its closer to the `kubectl` convention
- Allow a `--vus-per-pod/-v` flag to customize the number of VUs per pod.

To test this, run a test script with and without the flag. `kubectl get nodes` and `kubectl get pods -o wide` should show you how the number of nodes will change with the flag. After the test finishes, make sure the nodes are scaled back down to 0.

---

The other major change is I've performance-tuned `statsite` to handle up to 2 million metrics a second. There may be some issues with the availability of `m5zn.xlarge` instances, which in that case, you can manually change the value to `m5.xlarge` in the `statsite_nodegroup_template.yaml` file. 

Resolves #97; Resolves #36; Resolves #90 