### PR TITLE
update edamame init to avoid unnecessary redeploys

### DIFF
--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -141,6 +141,10 @@ const kubectl = {
     return exec(`kubectl delete ${type} ${name}`);
   },
 
+  getCrds() {
+    return exec(`kubectl get customresourcedefinitions`);
+  },
+
   getPv(type, name) {
     return exec(`kubectl get ${type} ${name}`);
   },


### PR DESCRIPTION
specifically, update `deployServersK6Op` to add a check to prevent redeploying to the cluster resources that have already been successfully deployed