### PR TITLE
update runTest to prevent user from running more than 1 test at a time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 manifests/load_test_crds/*
 manifests/db_api_ingress.yaml
 build
+testIsRunning.txt


### PR DESCRIPTION
After the initial checks that a user specified an appropriate load test file and a unique test name in runTest.js, added a check to see if a testIsRunning.txt file exists. This solution is using a local file's existence as a way to flag that a test is running, because otherwise could run into network latency issues when trying to assess if a load test is running that would allow a user to sneak through and problematically run 2 tests at once.

Specifically, if don't flag locally that a test is running, then would have to query the dbApi to see if a test currently has a 'started' or 'running' status. The testIsRunning.txt file is generated after all the initial checks in runTest.js are conducted and is deleted after the test runs to completion.

Considered updating the already existing .env file to flag that a test is running locally, but decided creating a small text file was simpler, because the existing .env file is used to store configuration and application information. When running a test, we just need a quick way to check that the runTest's execution process has already begun, which can be flagged with the presence of a file and doesn't require storing specific info in the .env file.
