### PR TITLE
let users specify their desired availability zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ In order to execute a load test with the `edamame` command line interface or gra
 
 ### edamame init
 
-Usage: `edamame init`
+Usage: `edamame init --zones <comma_separated_list_of_desired_availability_zones_in_your_preferred_aws_region>`
+Example: `edamame init --zones us-west-2a,us-west-2b,us-west-2d`
 Outputs:
 
 ```
@@ -45,6 +46,7 @@ Outputs:
 **Notes**:
 
 - It can take as long as _20 minutes_ to create the cluster and apply the necessary permissions.
+- The --zones flag is optional and exists to provide greater configuration flexibility. You can create a cluster with the default availability zones in your preferred aws region by simply executing `edamame init`.
 - To access the Grafana dashboards, use the provided link. For now, the default Grafana username and password are used (`admin` and `admin`). In Grafana, navigate to the Dashboards. From within the default HTTP & WebSockets dashboard, select the `test name` for the data you wish to view. If no tests have been run, you may see an error until there are test names in the database to display.
 
 ### edamame run

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -2,14 +2,15 @@ import cluster from "../utilities/cluster.js";
 import Spinner from "../utilities/spinner.js";
 import password from "../utilities/password.js";
 
-const init = async () => {
+const init = async (options) => {
+  const zones = options.zones;
   const spinner = new Spinner(
     "Creating Edamame cluster... (this may take up to 20 minutes)"
   );
 
   try {
     await cluster.checkForAllInstallations();
-    await cluster.create();
+    await cluster.create(zones);
     spinner.succeed("Successfully created Edamame cluster.");
 
     spinner.info("Configuring EBS credentials...");

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -25,6 +25,7 @@ const NODE_GROUPS_TEMPLATE = "nodegroups_template.yaml";
 const NODE_GROUPS_FILE = "load_test_crds/nodegroups.yaml";
 const STATSITE_CM = "statsite-config";
 const STATSITE_CM_FOLDER = "statsite-config";
+const MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES = 3;
 const DISPLAY_TEST_TITLE_SPACES = 30;
 const DISPLAY_TESTS_NUM_DASHES = 83;
 const DB_API_FILE = "db_api_deployment.yaml";
@@ -82,5 +83,6 @@ export {
   AWS_LBC_POLICY_REGEX,
   AWS_LBC_IAM_POLNAME,
   AWS_LBC_CHART_VERSION,
+  MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES,
   DASHBOARD_PORT,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,11 @@ const program = new Command();
 
 program
   .command("init")
+  .option("-z, --zones <zones>", "List of one or more desired cluster availability zones specific to a user's preferred aws region")
   .description(
     "Create an EKS cluster and deploy Grafana, Postgres, & K6 Operator"
   )
-  .action(() => {
-    init();
-  });
+  .action(init);
 
 program
   .command("run")

--- a/src/utilities/cluster.js
+++ b/src/utilities/cluster.js
@@ -62,14 +62,14 @@ const cluster = {
     }
   },
 
-  async create() {
+  async create(zones) {
     const { stdout } = await eksctl.clusterDesc();
     if (!stdout.match(CLUSTER_NAME)) {
       // delete old edamame stacks if there was an AWS failure that didn't cleanly delete all old stacks
       await aws.deleteOldStacks();
-      await eksctl.createCluster();
+      await eksctl.createCluster(zones);
     }
-
+    
     await eksctl.createNodeGroups();
     await this.applyStatsiteManifests();
   },

--- a/src/utilities/eksctl.js
+++ b/src/utilities/eksctl.js
@@ -1,5 +1,5 @@
+import aws from "./aws.js";
 import files from "./files.js";
-import iam from "./iam.js";
 import { promisify } from "util";
 import child_process from "child_process";
 import {
@@ -7,8 +7,7 @@ import {
   LOAD_GEN_NODE_GRP,
   STATSITE_NODE_GRP,
   NODE_GROUPS_TEMPLATE,
-  NODE_GROUPS_FILE,
-  AWS_LBC_IAM_POLNAME,
+  NODE_GROUPS_FILE
 } from "../constants/constants.js";
 const exec = promisify(child_process.exec);
 
@@ -24,8 +23,15 @@ const eksctl = {
     }
   },
 
-  createCluster() {
-    return exec(`eksctl create cluster --name ${CLUSTER_NAME} --version=1.25`);
+  async createCluster(zones) {
+    let command = `eksctl create cluster --name ${CLUSTER_NAME} --version=1.25`;
+    if (!zones) {
+      return exec(command);
+    }
+
+    await aws.throwErrorIfInvalidZone(zones);
+    command += ` --zones ${zones}`;
+    return exec(command);
   },
 
   clusterDesc() {


### PR DESCRIPTION
- update `edamame init` functionality to add optional flag that allows users to specify which availability zone(s) they want to use when the eks cluster is configured in their preferred aws region
- add checks that leverage `aws` cli commands to ensure that if the user specifies availability zones, those zones exist within their configured aws region
- update readme to call out the optional --zones flag now available to call when executing `edamame init` 