### PR TITLE
update run test error handling to clarify slow DNS configuration

### DIFF
--- a/src/commands/runTest.js
+++ b/src/commands/runTest.js
@@ -1,10 +1,9 @@
-import loadGenerators from "../utilities/loadGenerators.js";
+import files from "../utilities/files.js";
+import dbApi from "../utilities/dbApi.js";
 import Spinner from "../utilities/spinner.js";
 import cluster from "../utilities/cluster.js";
-import kubectl from "../utilities/kubectl.js";
 import manifest from "../utilities/manifest.js";
-import dbApi from "../utilities/dbApi.js";
-import files from "../utilities/files.js";
+import loadGenerators from "../utilities/loadGenerators.js";
 
 const runTest = async (options) => {
   const spinner = new Spinner("Initializing load test...");
@@ -65,6 +64,13 @@ const runTest = async (options) => {
   } catch (err) {
     spinner.fail(`Error running test: ${err}`);
     if (err["stdout"]) console.log(err["stdout"]);
+    if (!err.message.match(`load test is already in progress.`)) {
+      files.delete("testIsRunning.txt");
+    }
+    
+    if (err.message.match("getaddrinfo ENOTFOUND k8s-default-ingressd")) {
+      console.log("The DNS is still being configured for the DB API. Please try re-executing a load test in a couple minutes");
+    }
   }
 };
 

--- a/src/commands/stopTest.js
+++ b/src/commands/stopTest.js
@@ -3,6 +3,7 @@ import cluster from "../utilities/cluster.js";
 import manifest from "../utilities/manifest.js";
 import dbApi from "../utilities/dbApi.js";
 import { KubeConfig, CustomObjectsApi } from "@kubernetes/client-node";
+import files from "../utilities/files.js";
 
 const stopTest = async () => {
   const kc = new KubeConfig();
@@ -19,6 +20,7 @@ const stopTest = async () => {
     await cluster.phaseOutK6();
     dbApi.updateTestStatus(testId, "completed");
     spinner.succeed(`Stopped current test.`);
+    files.delete("testIsRunning.txt");
   } else {
     spinner.succeed(`No tests currently running.`);
   }


### PR DESCRIPTION
and notify user to re-execute a test in a couple minutes. Also, implement deleting the local testIsRunning file flag if this DNS related error occurs.

An alternative approach would be to programmatically implement a retry after a delay on runTest if the DNS related error (with message `getaddrinfo ENOTFOUND`) occurs. A programmatic retry approach wasn't selected since this issue only occurs on initial cluster configuration and if the user is fast enough to beat the DNS configuration process, which is a small portion of the total cluster lifetime.