### PR TITLE
Add timeout for the rare occurrence when AWS load gen and agg node ty…

### DIFF
--- a/manifests/load_agg_nodegroup_temp.yaml
+++ b/manifests/load_agg_nodegroup_temp.yaml
@@ -1,0 +1,20 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: edamame
+  region: us-east-1 # default value
+
+managedNodeGroups:
+  - name: ng-agg
+    instanceType: m5zn.xlarge # Testing: m5.large; Production: m5zn.xlarge
+    desiredCapacity: 0
+    minSize: 0
+    maxSize: 1
+    preBootstrapCommands:
+      - sysctl -w net.core.rmem_default=536870912 # Set to 512M
+      - sysctl -w net.core.rmem_max=536870912 # Set to 512M
+    taints:
+      - key: "special"
+        value: "sysctl-udp-buffer"
+        effect: NoSchedule

--- a/manifests/load_gen_nodegroup_temp.yaml
+++ b/manifests/load_gen_nodegroup_temp.yaml
@@ -5,20 +5,6 @@ metadata:
   name: edamame
   region: us-east-1 # default value
 
-managedNodeGroups:
-  - name: ng-agg
-    instanceType: m5zn.xlarge # Testing: m5.large; Production: m5zn.xlarge
-    desiredCapacity: 0
-    minSize: 0
-    maxSize: 1
-    preBootstrapCommands:
-      - sysctl -w net.core.rmem_default=536870912 # Set to 512M
-      - sysctl -w net.core.rmem_max=536870912 # Set to 512M
-    taints:
-      - key: "special"
-        value: "sysctl-udp-buffer"
-        effect: NoSchedule
-
 nodeGroups:
   - name: ng-gen
     instanceType: m5.24xlarge # Testing: m5.large; Production: m5.24xlarge

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -4,6 +4,8 @@ const DB_API_PORT = 4444;
 const GRAF_PORT = 3000;
 const DASHBOARD_PORT = 3001;
 const PORT_FORWARD_DELAY = 3500;
+const LOAD_GEN_NODE_TYPE = "m5.24xlarge";
+const LOAD_AGG_NODE_TYPE = "m5zn.xlarge";
 const DB_API_SERVICE = "db-api-service";
 const DB_API_INGRESS_NAME = "ingress-db-api";
 const EXTERNAL_IP_REGEX = "amazonaws.com";
@@ -21,8 +23,11 @@ const PG_CM_FILE = "postgres_configmap.yaml";
 const PG_SS_FILE = "postgres_statefulset.yaml";
 const STATSITE_FILE = "statsite_deployment.yaml";
 const STATSITE_NODE_GRP = "ng-agg";
-const NODE_GROUPS_TEMPLATE = "nodegroups_template.yaml";
-const NODE_GROUPS_FILE = "load_test_crds/nodegroups.yaml";
+const GEN_NODE_GROUP_TEMPLATE = "load_gen_nodegroup_temp.yaml";
+const AGG_NODE_GROUP_TEMPLATE = "load_agg_nodegroup_temp.yaml";
+const GEN_NODE_GROUP_FILE = "load_test_crds/load_gen_nodegroup.yaml";
+const AGG_NODE_GROUP_FILE = "load_test_crds/load_agg_nodegroup.yaml";
+const SPECIALIZED_NODES_UNAVAILABLE_TIMEOUT = 480000;
 const STATSITE_CM = "statsite-config";
 const STATSITE_CM_FOLDER = "statsite-config";
 const MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES = 3;
@@ -66,13 +71,15 @@ export {
   PG_CM_FILE,
   PG_SS_FILE,
   STATSITE_FILE,
-  NODE_GROUPS_TEMPLATE,
+  GEN_NODE_GROUP_TEMPLATE,
+  AGG_NODE_GROUP_TEMPLATE,
   STATSITE_NODE_GRP,
   STATSITE_CM,
   STATSITE_CM_FOLDER,
   DISPLAY_TEST_TITLE_SPACES,
   DISPLAY_TESTS_NUM_DASHES,
-  NODE_GROUPS_FILE,
+  GEN_NODE_GROUP_FILE,
+  AGG_NODE_GROUP_FILE,
   DB_API_FILE,
   CLUSTER_NAME,
   LOAD_GEN_NODE_GRP,
@@ -84,5 +91,8 @@ export {
   AWS_LBC_IAM_POLNAME,
   AWS_LBC_CHART_VERSION,
   MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES,
+  SPECIALIZED_NODES_UNAVAILABLE_TIMEOUT,
   DASHBOARD_PORT,
+  LOAD_GEN_NODE_TYPE,
+  LOAD_AGG_NODE_TYPE
 };

--- a/src/utilities/aws.js
+++ b/src/utilities/aws.js
@@ -1,6 +1,7 @@
 import { 
   AWS_LBC_IAM_POLNAME,
   CLUSTER_NAME,
+  GEN_NODE_GROUP_FILE,
   MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES
 } from "../constants/constants.js";
 import { promisify } from "util";
@@ -45,9 +46,10 @@ const aws = {
   checkForInvalidZoneList(zones) {
     let numDashes = zones.split("").filter(char => char === "-").length;
     if (!zones.match(",") && numDashes >= MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES) {
-      throw Error (
-        `When specifying >1 availability zones, please specify the desired zones as a comma separated list like so: "us-east-1a,us-east-1b"`
-      );
+      let msg = `When specifying >1 availability zones, please ` +
+        `specify the desired zones as a comma separated list` +
+        ` like so: "us-east-1a,us-east-1b"`;
+      throw Error (msg);
     }
   },
 
@@ -94,6 +96,34 @@ const aws = {
       return exec(
         `aws iam delete-policy --policy-arn ${policy}`
       );
+    }
+  },
+
+  async checkOfferedInstanceTypes(nodeType) {
+    const nodeGroupData = files.readYAML(GEN_NODE_GROUP_FILE);
+    const region = nodeGroupData.metadata.region;
+
+    const command = `aws ec2 describe-instance-type-offerings ` +
+      `--location-type availability-zone --filters Name=instance-type,` +
+      `Values=${nodeType} --region ${region} --output table`;
+
+    const { stdout } = await exec(command);
+    let msg = `Edamame has checked the instance types available in your ` +
+      `AWS region, ${region}, and the ${nodeType} nodes are`;
+
+    if (stdout.match(nodeType)) {
+      console.log(`${msg} generally available:`);
+      console.log(stdout);
+      console.log("If you initialized the Edamame cluster with the optional --zones " +
+        "flag, please double check that you specified at least one of the availability " +
+        "zones shown in the table output above.");
+      console.log("Otherwise, please try executing your load test again later, " +
+        "as the required AWS instance types should become available again.");
+    } else {
+      console.log(`${msg} not generally available:`);
+      console.log(stdout);
+      console.log(`Please switch AWS regions or contact Edamame developers, so ` +
+        `that we can extend Edamame's options for you region's specialized needs.`);
     }
   },
 

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -157,9 +157,9 @@ const kubectl = {
     return exec(`kubectl get pods`);
   },
 
-  async getGeneratorNodes() {
+  async getLoadNodes(nodeGroup) {
     const { stdout } = await exec(
-      `kubectl get nodes --selector alpha.eksctl.io/nodegroup-name=ng-gen`
+      `kubectl get nodes --selector alpha.eksctl.io/nodegroup-name=${nodeGroup}`
     );
     const nodes = stdout
       .split("\n")
@@ -168,16 +168,17 @@ const kubectl = {
     return nodes;
   },
 
-  async getGeneratorNodesCount() {
-    const nodes = await this.getGeneratorNodes();
+  async getLoadNodesCount(nodeGroup) {
+    const nodes = await this.getLoadNodes(nodeGroup);
     return nodes.length;
   },
 
-  async getGeneratorNodesReadyCount() {
-    const nodes = await this.getGeneratorNodes();
+  async getLoadNodesReadyCount(nodeGroup) {
+    const nodes = await this.getLoadNodes(nodeGroup);
     const readyNodes = nodes.filter((node) => node.match(/\sReady\s/));
     return readyNodes.length;
   },
+
   // If there's a process on a port, it kills it, otherwise it throws an error
   async stopProcessOnPort(port) {
     try {


### PR DESCRIPTION
…pes are unavailable

If either the m5 load generator or aggregator node types are unavailable, this proposed timeout logic will:
* Stop the polling process that continues until the load generator and load aggregator nodes are ready
* Display to the user the instance type that failed to be ready and show the availability zones in the user’s region that the instance type is generally available in
* Delete the new record that was entered into the database’s test table for the current test that won't finish executing b/c the appropriate nodes aren't available
* Request the user to re-execute the load test again later since AWS server availability does change and the specific m5 nodes should become available again w/in the user’s region
    * It would be nice to give a specific time at which the user should try again, but don’t have a good way to assess when AWS’s availability will change
    * Considered implementing a failover option where other instance types are used, but those instance types may have the same lack of availability issue, and would require re-tuning the number of vus per pod given the performance of these failover instance types would be different. Also, the lack of availability of these m5 instances has been rare. As a result, didn’t pursue the failover option.


Timeout messages added:
![load_gen_timeout](https://github.com/edamame-load-test/edamame/assets/76174119/de708ea1-e4ef-4ec2-be66-ee6f362b0da0)
![load_agg_timeout](https://github.com/edamame-load-test/edamame/assets/76174119/6fd60aea-cc03-44f2-9c45-6e777b60f00e)




