### PR TITLE
add archive and delete-from-archive commands and all supporting logic…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ manifests/load_test_crds/*
 manifests/db_api_ingress.yaml
 build
 manifests/testIsRunning.txt
-manifests/pg_dump/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 manifests/load_test_crds/*
 manifests/db_api_ingress.yaml
 build
-testIsRunning.txt
+manifests/testIsRunning.txt
+manifests/pg_dump/*

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Outputs:
 ### edamame delete-from-archive
 
 Usage: `edamame delete-from-archive --all`
-Alternative Usage: `edamame delte-from-archive --name "100K VUs"`
+Alternative Usage: `edamame delete-from-archive --name "100K VUs"`
 Outputs:
 
 ```

--- a/README.md
+++ b/README.md
@@ -253,6 +253,39 @@ Outputs:
 - Ends local access to the graphical user interface (GUI) and the Grafana dashboard.
 - This frees up ports 3000 and 3001 for other processes.
 
+### edamame archive
+
+Usage: `edamame archive --all`
+Alternative Usage: `edamame archive --name "100K VUs"`
+Outputs:
+
+```
+[04:08:56:294] ℹ Starting archive process...
+[04:08:56:544] ℹ Creating edamame-load-tests AWS S3 Bucketlocated at: aws-region=us-west-2
+ if it doesn't exist yet...
+[04:09:01:715] ℹ AWS S3 Bucket is ready for uploads.
+[04:09:03:366] ℹ Successfully archived 100K VUs.
+[04:09:03:366] ✔ Archival process complete. Uploaded 1 load test objects to the AWS S3 Bucket: edamame-load-tests
+```
+
+- Uploads 1 load test or all load tests to an AWS S3 Bucket as S3 objects with the standard infrequent access storage class.
+- Purpose: allow user to back up their load test data to AWS S3 in case they need to teardown their Edamame EKS cluster for a period of time. A user should execute this command prior to executing `edamame teardown`.
+- There isn't support yet for changing the S3 object's storage class to another class via the Edamame CLI. If a user wants to change the storage class to a Glacier category for even cheaper storage they can do so, but will currently need to use the AWS CLI.
+
+### edamame delete-from-archive
+
+Usage: `edamame delete-from-archive --all`
+Alternative Usage: `edamame delte-from-archive --name "100K VUs"`
+Outputs:
+
+```
+[04:17:18:812] ℹ Starting archival deletion process...
+[04:17:21:787] ✔ Successfully deleted 100K VUs from the AWS S3 Bucket: edamame-load-tests
+```
+
+- Deletes 1 load test S3 object from the AWS S3 Bucket in case the user no longer wants to store that test's data.
+- If the --all flag is provided then all S3 objects and the user's load test AWS S3 Bucket will be deleted.
+
 ### edamame teardown
 
 Usage: `edamame teardown`

--- a/manifests/db_api_deployment.yaml
+++ b/manifests/db_api_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: db-api
-          image: rachwest/edamame-db-api:latest
+          image: rachwest/edamame:latest
           ports:
             - containerPort: 4444
           env:
@@ -47,6 +47,33 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: postgres-password
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: aws-region
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: aws-access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: aws-secret-access-key
+            - name: AWS_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: aws-account-id
+          volumeMounts:
+            - name: pg-dump
+              mountPath: /var/pg_dump
+      volumes:
+        - name: pg-dump
+          emptyDir:
+            sizeLimit: 500Mi
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/db_api_deployment.yaml
+++ b/manifests/db_api_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: db-api
-          image: rachwest/edamame:latest
+          image: rachwest/edamame-db-api:latest
           ports:
             - containerPort: 4444
           env:

--- a/manifests/postgres_statefulset.yaml
+++ b/manifests/postgres_statefulset.yaml
@@ -68,8 +68,7 @@ data:
         start_time timestamp NOT NULL DEFAULT now(),
         end_time timestamp,
         status varchar(10) NOT NULL DEFAULT 'starting',
-        script text,
-        archive_id varchar(255) DEFAULT ''
+        script text
       );
       CREATE TABLE samples (
         id SERIAL PRIMARY KEY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/preset-env": "^7.20.2",
         "babel-plugin-transform-import-meta": "^2.2.0",
         "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.6.1",
         "mock-fs": "^5.2.0",
         "test": "^3.3.0",
         "ts-node": "^10.9.1",
@@ -2023,15 +2024,15 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
-      "integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
+      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.5.0"
+        "jest-mock": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2063,17 +2064,17 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
-      "integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
+      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.5.0",
-        "jest-mock": "^29.5.0",
-        "jest-util": "^29.5.0"
+        "jest-message-util": "^29.6.1",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2218,12 +2219,12 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
+      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
       "dev": true,
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2375,12 +2376,12 @@
       "dev": true
     },
     "node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.1.tgz",
+      "integrity": "sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -2514,9 +2515,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -2535,6 +2536,15 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2645,6 +2655,17 @@
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
       "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA=="
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
@@ -2701,6 +2722,12 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "dev": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2725,6 +2752,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -2732,6 +2769,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3517,6 +3566,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3526,6 +3599,20 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dateformat": {
@@ -3552,6 +3639,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -3630,6 +3723,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3662,6 +3767,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3769,6 +3886,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3780,6 +3918,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
@@ -4268,11 +4415,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -4288,6 +4461,19 @@
         "npm": ">=1.3.7"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4295,6 +4481,18 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-local": {
@@ -4504,6 +4702,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -5144,6 +5348,33 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.6.1.tgz",
+      "integrity": "sha512-PoY+yLaHzVRhVEjcVKSfJ7wXmJW4UqPYNhR05h7u/TK0ouf6DmRNZFBL/Z00zgQMyWGMBXn69/FmOvhEJu8cIw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.6.1",
+        "@jest/fake-timers": "^29.6.1",
+        "@jest/types": "^29.6.1",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.6.1",
+        "jest-util": "^29.6.1",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.5.0.tgz",
@@ -5273,18 +5504,18 @@
       "dev": true
     },
     "node_modules/jest-message-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
-      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
+      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.6.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -5342,14 +5573,14 @@
       "dev": true
     },
     "node_modules/jest-mock": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
-      "integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
+      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-util": "^29.5.0"
+        "jest-util": "^29.6.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5725,12 +5956,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
+      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -5978,9 +6209,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -5997,6 +6226,80 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -6338,6 +6641,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+      "dev": true
+    },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -6528,6 +6837,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6605,12 +6926,12 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.6.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
+      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -6650,6 +6971,14 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
@@ -6674,10 +7003,10 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
     "node_modules/react": {
@@ -6699,6 +7028,12 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.1",
@@ -6871,6 +7206,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -6989,6 +7330,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -7330,6 +7683,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -7503,12 +7862,16 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/ts-node": {
@@ -7683,6 +8046,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -7717,12 +8089,14 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "engines": {
-        "node": ">=6"
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7773,6 +8147,18 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -7788,6 +8174,49 @@
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -7949,6 +8378,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "edamame": "src/index.js"
   },
   "scripts": {
-    "test": "jest"
+    "test:cli": "jest --testPathPattern=src/__tests__/cli_tests/"
   },
   "keywords": [],
   "license": "ISC",
@@ -34,6 +34,7 @@
     "@babel/preset-env": "^7.20.2",
     "babel-plugin-transform-import-meta": "^2.2.0",
     "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.6.1",
     "mock-fs": "^5.2.0",
     "test": "^3.3.0",
     "ts-node": "^10.9.1",

--- a/src/__tests__/cli_tests/manifest.js
+++ b/src/__tests__/cli_tests/manifest.js
@@ -1,7 +1,5 @@
-import manifest from "../utilities/manifest.js";
+import manifest from "../../utilities/manifest.js";
 import mock from "mock-fs";
-import yaml from "js-yaml";
-
 
 beforeAll(() => { 
   mock({

--- a/src/commands/archive.js
+++ b/src/commands/archive.js
@@ -1,0 +1,65 @@
+import aws from "../utilities/aws.js";
+import dbApi from "../utilities/dbApi.js";
+import files from "../utilities/files.js";
+import Spinner from "../utilities/spinner.js";
+import { ARCHIVE } from "../constants/constants.js";
+
+const archive = async (options) => {
+  const spinner = new Spinner("Starting archive process...");
+  const testName = options.name;
+  let testsToArchive;
+  
+  try {
+    if (testName) {
+      const test = await dbApi.getTest(testName);
+      if (!test) {
+        throw new Error(`Nonexistent test to archive: ${testName}.`);
+      }
+      testsToArchive = [test];
+    } else {
+      testsToArchive = await dbApi.getAllTests();
+      if (testsToArchive.length === 0) {
+        throw new Error(`There are no tests to archive.`);
+      }
+    }
+    let region = files.read(files.path("postgres.env")).match("aws-region=.{1,}\n")[0];
+    spinner.info(
+      `Creating ${ARCHIVE} AWS S3 Bucket` +
+      `located at: ${region} if it doesn't exist yet...`
+    );
+    await aws.setUpArchiveBucket();
+    spinner.info("AWS S3 Bucket is ready for uploads.");
+    let numArchived = 0;
+    
+    for (let i = 0; i < testsToArchive.length; i++) {
+      let name = testsToArchive[i].name;
+      try {
+        const exists = aws.s3ObjectExists(aws.s3ObjectNameForTest(name));
+        if (!exists) {
+          spinner.info(`Archive for ${name} already exists. Skipping to next archive step.`);
+        } else {
+          await dbApi.archiveTest(name);
+          spinner.info(`Successfully archived ${name}.`);
+          numArchived += 1;
+        }
+      } catch (error) {
+        console.log(error);
+        spinner.info(
+          `There was an issue archiving your load test: ${name}.` +
+          ` It seems your load test had enough data to exceed the` +
+          ` upload size limit. Please reach out to an edamame` +
+          ` developer for a custom archive solution for this test.`
+        );
+      }
+    }
+
+    spinner.succeed(
+      `Archival process complete. Uploaded ${numArchived} load ` +
+      `test objects to the AWS S3 Bucket: ${ARCHIVE}`
+    );
+  } catch (err) {
+    spinner.fail(`Error archiving load test data: ${err}`);
+  }
+};
+
+export { archive };

--- a/src/commands/deleteFromArchive.js
+++ b/src/commands/deleteFromArchive.js
@@ -1,0 +1,34 @@
+import aws from "../utilities/aws.js";
+import dbApi from "../utilities/dbApi.js";
+import Spinner from "../utilities/spinner.js";
+import { 
+  ARCHIVE
+} from "../constants/constants.js";
+
+const deleteFromArchive = async (options) => {
+  const spinner = new Spinner("Starting archival deletion process...");
+  const testName = options.name;
+
+  try {
+    if (testName) {
+      const test = await dbApi.getTest(testName);
+      if (!test) {
+        throw new Error(`Nonexistent test to unarchive: ${testName}.`);
+      }
+      await aws.deleteObjectFromS3Bucket(`${testName}.tar.gz`);
+      spinner.succeed(
+        `Successfully deleted ${testName} from the AWS S3 Bucket: ${ARCHIVE}`);
+    } else {
+      await aws.deleteS3Bucket();
+      spinner.succeed(`Deleted AWS S3 bucket: ${ARCHIVE}`);
+    }
+  } catch (err) {
+    if (err.stderr.match("NoSuchBucket")) {
+      spinner.fail(`There's no AWS S3 ${ARCHIVE} bucket to delete.`);
+    } else {
+      spinner.fail(`Error deleting load test data from AWS S3 storage: ${err}`);
+    }
+  }
+};
+
+export { deleteFromArchive };

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -25,7 +25,7 @@ const init = async (options) => {
     await password.assign();
     spinner.info("Deploying Grafana, Postgres, & K6 Operator...");
     spinner.start();
-    const grafanaUrl = await cluster.deployServersK6Op();
+    await cluster.deployServersK6Op();
     spinner.succeed("Cluster configured. Welcome to Edamame!");
   } catch (err) {
     spinner.fail(`Error creating cluster: ${err}`);

--- a/src/commands/runTest.js
+++ b/src/commands/runTest.js
@@ -61,7 +61,7 @@ const runTest = async (options) => {
     await loadGenerators.pollUntilAllComplete(numNodes);
     await dbApi.updateTestStatus(testId, "completed");
     spinner.succeed("Load test completed.");
-
+    
     spinner.info("Tearing down load test resources.");
     spinner.start();
     await cluster.phaseOutK6();

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -4,6 +4,7 @@ const DB_API_PORT = 4444;
 const GRAF_PORT = 3000;
 const DASHBOARD_PORT = 3001;
 const PORT_FORWARD_DELAY = 3500;
+const ARCHIVE = "edamame-load-tests";
 const LOAD_GEN_NODE_TYPE = "m5.24xlarge";
 const LOAD_AGG_NODE_TYPE = "m5zn.xlarge";
 const DB_API_SERVICE = "db-api-service";
@@ -56,6 +57,7 @@ export {
   DB_API_INGRESS,
   DB_API_ING_TEMPLATE,
   DB_API_INGRESS_NAME,
+  ARCHIVE,
   PG_CM,
   GRAF,
   GRAF_DS,

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ import { stopTest } from "./commands/stopTest.js";
 import { NUM_VUS_PER_POD } from "./constants/constants.js";
 import { Command } from "commander";
 import { startGui, stopGui } from "./commands/gui.js";
+import { archive } from "./commands/archive.js";
+import { deleteFromArchive } from "./commands/deleteFromArchive.js";
+import { ARCHIVE } from "./constants/constants.js";
 
 const program = new Command();
 
@@ -85,7 +88,7 @@ program
   .description("Spin up grafana, and the express app serving react")
   .action(async (options) => {
     if (options.start) {
-      await portForwardGrafana(); // Spin up grafana
+      await portForwardGrafana();
       startGui();
     } else if (options.stop) {
       stopGui();
@@ -98,5 +101,22 @@ program
   .action(() => {
     destroyEKSCluster();
   });
+
+program
+  .command("archive")
+  .option("--all", `Upload all load tests as S3 Objects to the ${ARCHIVE} AWS S3 Bucket`)
+  .option("-n, --name <name>", "Name of specific test to archive")
+  .description(
+    `Move load test data from EBS volume to AWS S3 Glacier to allow for persistent test ` +
+    ` data storage beyond the life of the Edamame EKS cluster. If test name flag isn't ` +
+    ` provided, then all existing test data will be archived. `
+  ).action(archive);
+
+program
+  .command("delete-from-archive")
+  .option("--all", `Delete entire ${ARCHIVE} AWS S3 Bucket`)
+  .option("-n, --name <name>", "Name of specific test to remove from the AWS S3 Bucket")
+  .description(`Delete specific load test from the ${ARCHIVE} AWS S3 Bucket or delete the entire bucket`)
+  .action(deleteFromArchive);
 
 program.parse(process.argv);

--- a/src/utilities/aws.js
+++ b/src/utilities/aws.js
@@ -1,8 +1,9 @@
 import { 
   AWS_LBC_IAM_POLNAME,
   CLUSTER_NAME,
+  ARCHIVE,
   GEN_NODE_GROUP_FILE,
-  MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES
+  MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES,
 } from "../constants/constants.js";
 import { promisify } from "util";
 import iam from "./iam.js";
@@ -39,7 +40,10 @@ const aws = {
     }
 
     if (invalid) {
-      throw Error (`One of your specified zones, ${invalidZone}, isn't in the list of aws availability zones for your region`);
+      let msg = `One of your specified zones, ` +
+        `${invalidZone}, isn't in the list of aws ` +
+        `availability zones for your region`;
+      throw Error(msg);
     }
   },
 
@@ -54,12 +58,15 @@ const aws = {
   },
 
   async usersPossibleZones() {
-    let zones = await exec(`aws ec2 describe-availability-zones --all-availability-zones`);
-    zones = zones.stdout.split("\n").filter(line => line.match(`"ZoneName"`));
+    const command = `aws ec2 describe-availability-zones` +
+      ` --all-availability-zones`;
+    const { stdout } = await exec(command);
+    let zones = stdout.split("\n").filter(line => line.match(`"ZoneName"`));
     let zonesLookup = {};
 
     zones.forEach(zoneDesc => {
-      let zoneKey = zoneDesc.split(`"ZoneName": `).filter(info => info !== "")[1].replace(",", "").replaceAll(`"`, "");
+      let zoneKey = zoneDesc.split(`"ZoneName": `).filter(info => info !== "")[1];
+      zoneKey = zoneKey.replace(",", "").replaceAll(`"`, "");
       zonesLookup[zoneKey] = zoneDesc;
     });
 
@@ -103,11 +110,7 @@ const aws = {
     const nodeGroupData = files.readYAML(GEN_NODE_GROUP_FILE);
     const region = nodeGroupData.metadata.region;
 
-    const command = `aws ec2 describe-instance-type-offerings ` +
-      `--location-type availability-zone --filters Name=instance-type,` +
-      `Values=${nodeType} --region ${region} --output table`;
-
-    const { stdout } = await exec(command);
+    const { stdout } = await this.describeInstanceTypes(nodeType, region);
     let msg = `Edamame has checked the instance types available in your ` +
       `AWS region, ${region}, and the ${nodeType} nodes are`;
 
@@ -127,10 +130,21 @@ const aws = {
     }
   },
 
+  async describeInstanceTypes(nodeType, region) {
+    const command = `aws ec2 describe-instance-type-offerings ` +
+      `--location-type availability-zone ` +
+      `--filters Name=instance-type,` +
+      `Values=${nodeType} --region ${region} `+
+      `--output table`;
+
+    return exec(command);
+  },
+
   async deleteEBSVolumes() {
     let volumesCommand = `aws ec2 describe-volumes --filter ` +
-      `"Name=tag:kubernetes.io/created-for/pvc/name,Values=data-postgres-0,grafana-pvc"` +
-      ` --query 'Volumes[].VolumeId' --output json`;
+      `"Name=tag:kubernetes.io/created-for/pvc/name,` +
+      `Values=data-postgres-0,grafana-pvc" --query` +
+      ` 'Volumes[].VolumeId' --output json`;
 
     let volumes = await exec(`${volumesCommand}`);
     volumes = JSON.parse(volumes.stdout);
@@ -140,7 +154,76 @@ const aws = {
         exec(`aws ec2 delete-volume --volume-id ${volume}`);
       })
     );
-  }
+  },
+
+  async getConfiguration(type) {
+    const { stdout } = await exec(`aws configure get ${type}`);
+    return stdout.replace("\n", "");
+  },
+
+  async getAccountId() {
+    const { stdout } = await exec('aws sts get-caller-identity');
+    let accountId = stdout.match(/Account": .{1,}"/)[0];
+    return accountId.split(": ")[1];
+  },
+
+  async currentCLICredentials() {
+    let region = await this.getConfiguration('region');
+    let accountId = await this.getAccountId();
+    let accessKey = await this.getConfiguration('aws_access_key_id');
+    let secretKey = await this.getConfiguration('aws_secret_access_key');
+    return {
+      region,
+      accountId,
+      accessKey,
+      secretKey
+    };
+  },
+
+  archiveBucketExists: async () => {
+    try {
+      await exec(`aws s3 ls s3://${ARCHIVE}`);
+      return true;
+    } catch (error) {
+      if (error.stderr.match("NoSuchBucket")) {
+        return false;
+      } else { // unknown error; abort process
+        throw Error(error);
+      }
+    }
+  },
+
+  s3ObjectNameForTest(testName) {
+    return `${testName.replaceAll("-", "")}.tar.gz`;
+  },
+
+  async s3ObjectExists(file) {
+    try {
+      await exec(`aws s3api head-object --bucket ${ARCHIVE} --key ${file}`);
+      return true;
+    } catch (error) {
+      if (error.stderr.match("Not Found")) { // file doesn't exist yet
+        return false;
+      } else { // unknown error; abort process
+        throw Error(error);
+      }
+    }
+  },
+
+  async setUpArchiveBucket() {
+    let exists = await this.archiveBucketExists();
+    if (!exists) {
+      await exec(`aws s3 mb s3://${ARCHIVE}`);
+    }
+  },
+
+  async deleteS3Bucket() {
+    await exec(`aws s3 rb s3://${ARCHIVE} --force`);
+  },
+
+  async deleteObjectFromS3Bucket(key) {
+    await exec(`aws s3api delete-object --bucket ${ARCHIVE} --key ${key}`);
+  },
 };
 
 export default aws;

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -193,14 +193,15 @@ const dbApi = {
     }
   },
 
-  async setUpArchive(testName) {
-    const url = `${this.url()}/pg_dump/${testName}`;
+  async archiveTest(testName) {
+    const url = `${this.url()}/archive/${testName}`;
 
     try {
-      await axios.post(`${url}`, {});
+      let response = await axios.post(`${url}`, {});
+      return response.data;
     } catch {
       await this.restoreIp();
-      const newUrl = `${this.url()}/pg_dump/${testName}`;
+      const newUrl = `${this.url()}/archive/${testName}`;
       let res = await axios.post(`${newUrl}`, {});
       return res.data;
     }

--- a/src/utilities/files.js
+++ b/src/utilities/files.js
@@ -2,6 +2,9 @@ import path from "path";
 import fs from "fs";
 import yaml from "js-yaml";
 import { fileURLToPath } from 'url';
+import { promisify } from "util";
+import child_process from "child_process";
+const exec = promisify(child_process.exec);
 
 const files = {
   exists(path) {
@@ -50,6 +53,15 @@ const files = {
 
   delete(fileName) {
     return fs.rm(this.path(fileName), (err) => err)
+  },
+
+  async filesInDir(directoryPath) {
+    if (!this.exists(directoryPath)) {
+      return 0;
+    }
+
+    const { stdout } = await exec(`cd ${directoryPath} && echo *`);
+    return stdout.replaceAll("\n", "").split(" ");
   }
 };
 

--- a/src/utilities/kubectl.js
+++ b/src/utilities/kubectl.js
@@ -5,7 +5,8 @@ import { spawn } from "child_process";
 const exec = promisify(child_process.exec);
 import { 
   AWS_LBC_CRD, 
-  LOAD_GEN_NODE_GRP } 
+  CLUSTER_NAME
+} 
 from "../constants/constants.js";
 
 const kubectl = {
@@ -192,7 +193,7 @@ const kubectl = {
     } catch (err) {
       console.log(`Error stopping process on port ${port}: ${err.message}`);
     }
-  },
+  }
 };
 
 export default kubectl;

--- a/src/utilities/manifest.js
+++ b/src/utilities/manifest.js
@@ -7,6 +7,7 @@ import {
   DB_API_ING_TEMPLATE,
   LOAD_GEN_NODE_GRP
 } from "../constants/constants.js";
+import aws from "./aws.js";
 import files from "./files.js";
 import kubectl from "./kubectl.js";
 import eksctl from "./eksctl.js";
@@ -102,10 +103,13 @@ const manifest = {
     return data.spec.script.configMap.name;
   },
 
-  setPgGrafCredentials(pw) {
-    const secretData = `postgres-username=${CLUSTER_NAME}\npostgres-password=${pw}`;
+  async setPgDbApiGrafCredentials(pw) {
+    let secretData = `postgres-username=${CLUSTER_NAME}\npostgres-password=${pw}\n`;
+    let awsData = await aws.currentCLICredentials();
+    secretData += `aws-region=${awsData.region}\naws-account-id=${awsData.accountId}\n`;
+    secretData += `aws-access-key-id=${awsData.accessKey}\naws-secret-access-key=${awsData.secretKey}\n`;
     files.write("postgres.env", secretData);
-    return kubectl.createSecret();
+    await kubectl.createSecret();
   },
 
   forEachGrafJsonDB(callback) {

--- a/src/utilities/password.js
+++ b/src/utilities/password.js
@@ -1,4 +1,3 @@
-import readlineSync from "readline-sync";
 import manifest from "./manifest.js";
 import crypto from 'crypto';
 
@@ -12,9 +11,9 @@ const password = {
     return result;
   },
 
-  assign() {
+  async assign() {
     const password = crypto.randomUUID();
-    return manifest.setPgGrafCredentials(password);
+    await manifest.setPgDbApiGrafCredentials(password);
   }
 };
 


### PR DESCRIPTION
… to allow users to persist load test data beyond the life of the AWS EKS cluster

More details:
- add logic to add user's AWS credentials to the kubernetes secret that the db api pod reads from 
- update db api deployment to read in AWS credentials from the k8s secret and to configure an emptyDir volume that the pod can temporarily read and write to (when the pod executes the pg data dump and uploads a compressed tar file to an AWS S3 Bucket as an S3 object with the standard infrequent access storage class)
- add archive and delete-from-archive commands
- update dbApi, aws, and other supporting utilities with error handling and appropriate logic that set up a load test specific AWS S3 Bucket and pass to the db api pod enough test information, so that the pod's underlying app can backup load test information in AWS S3 should a user need to teardown the EKS cluster
- update readme for the new CLI commands available