### PR TITLE
add commands for showing load tests archived to AWS S3 and for import…

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,21 +256,35 @@ Outputs:
 ### edamame archive
 
 Usage: `edamame archive --all`
-Alternative Usage: `edamame archive --name "100K VUs"`
+Alternative Usage: `edamame archive --name testName`
 Outputs:
+
+`$ edamame archive --name "100K VUs"`
 
 ```
 [04:08:56:294] ℹ Starting archive process...
-[04:08:56:544] ℹ Creating edamame-load-tests AWS S3 Bucketlocated at: aws-region=us-west-2
+[04:08:56:544] ℹ Creating load test AWS S3 Bucket located in: aws-region=us-west-2
  if it doesn't exist yet...
 [04:09:01:715] ℹ AWS S3 Bucket is ready for uploads.
 [04:09:03:366] ℹ Successfully archived 100K VUs.
-[04:09:03:366] ✔ Archival process complete. Uploaded 1 load test objects to the AWS S3 Bucket: edamame-load-tests
+[04:09:03:366] ✔ Archive process complete.
 ```
 
-- Uploads 1 load test or all load tests to an AWS S3 Bucket as S3 objects with the standard infrequent access storage class.
-- Purpose: allow user to back up their load test data to AWS S3 in case they need to teardown their Edamame EKS cluster for a period of time. A user should execute this command prior to executing `edamame teardown`.
-- There isn't support yet for changing the S3 object's storage class to another class via the Edamame CLI. If a user wants to change the storage class to a Glacier category for even cheaper storage they can do so, but will currently need to use the AWS CLI.
+`$ edamame archive --all`
+
+```
+[01:57:28:276] ℹ Starting archive process...
+[01:57:28:538] ℹ Creating load test AWS S3 Bucket located in: aws-region=us-west-2
+ if it doesn't exist yet...
+[01:57:30:170] ℹ AWS S3 Bucket is ready for uploads.
+[01:57:33:187] ℹ Successfully archived 45f4d3e5-5c52-4f3e-88e2-17a085b1c80f.
+[01:57:34:728] ℹ Archive for 100k VUs already exists. Skipping to next step.
+[01:57:34:728] ✔ Archive process complete.
+```
+
+- Uploads 1 or more load tests to an AWS S3 Bucket as S3 objects with the standard infrequent access storage class.
+- Purpose: allow user to back up their load test data to AWS S3 in case they need or want to teardown their Edamame EKS cluster, but want to persist their load test data. A user should execute this command prior to executing `edamame teardown`.
+- There isn't currently support for changing the S3 object's storage class to another class via the Edamame CLI. If a user wants to change the storage class to a Glacier category for even cheaper cold storage they can do so, but will need to use the AWS CLI or management console.
 
 ### edamame delete-from-archive
 
@@ -280,11 +294,45 @@ Outputs:
 
 ```
 [04:17:18:812] ℹ Starting archival deletion process...
-[04:17:21:787] ✔ Successfully deleted 100K VUs from the AWS S3 Bucket: edamame-load-tests
+[04:17:21:787] ✔ Successfully deleted 100K VUs from your Edamame load test AWS S3 Bucket.
 ```
 
-- Deletes 1 load test S3 object from the AWS S3 Bucket in case the user no longer wants to store that test's data.
-- If the --all flag is provided then all S3 objects and the user's load test AWS S3 Bucket will be deleted.
+- Permanently deletes 1 load test S3 object from the AWS S3 Bucket in case the user no longer wants to store that test's data.
+- If the --all flag is provided then all S3 objects and the user's entire load test AWS S3 Bucket will be permanently deleted.
+
+### edamame archive-contents
+
+Usage: `edamame archive-contents`
+
+Outputs:
+
+```
+[11:59:14:955] ℹ Loading AWS S3 Bucket archive details...
+[11:59:17:351] ✔ Your Edamame load test AWS S3 Bucket contains the following load test S3 objects:
+ > 100kVUs.tar.gz
+ > 120kVUs.tar.gz
+```
+
+- Shows the load tests that have been uploaded to AWS S3.
+- Each S3 object contains the data associated with one historical test.
+
+### edamame import-from-archive
+
+Usage: `edamame import-from-archive --all`
+Alternative Usage: `edamame import-from-archive --name testName`
+Outputs:
+
+`$ edamame import-from-archive --name "100K VUs"`
+
+```
+[02:29:28:602] ℹ Starting process to import AWS S3 archived data into Postgres database...
+[02:29:31:507] ℹ Successfully imported the test 100kVUs from your AWS S3 Bucket.
+[02:29:31:554] ✔ Completed importing data from AWS S3.
+```
+
+- Imports 1 or more load test S3 objects from the AWS S3 Bucket into the current AWS EKS cluster.
+- If the --all flag is provided then all load test AWS S3 objects will be imported.
+- If the import command is executed after a user executes load tests in their current cluster and there is an overlap in the import data and the data in the Postgres database in the cluster, then the import process will be aborted. There currently isn't support for importing data with a test that has the same name as a test that already exists in the Postgres database. As a result, it's recommended that a user executes `edamame import-from-archive` immediately after `edamame init` to avoid name collisions.
 
 ### edamame teardown
 

--- a/manifests/db_api_deployment.yaml
+++ b/manifests/db_api_deployment.yaml
@@ -87,4 +87,4 @@ spec:
     - protocol: TCP
       port: 4444
       targetPort: 4444
-      nodePort: 30001
+      nodePort: 30002

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "edamame": "src/index.js"
   },
   "scripts": {
-    "test:cli": "jest --testPathPattern=src/__tests__/cli_tests/"
+    "test:cli": "jest --testPathPattern=src/__tests__/cli/utilities",
+    "test:manifest": "jest --testPathPattern=src/__tests__/cli/manifests"
   },
   "keywords": [],
   "license": "ISC",

--- a/src/__tests__/cli/manifests/manifest.js
+++ b/src/__tests__/cli/manifests/manifest.js
@@ -1,10 +1,10 @@
-import manifest from "../../utilities/manifest.js";
+import manifest from "../../../utilities/manifest.js";
 import mock from "mock-fs";
 
-beforeAll(() => { 
+beforeAll(() => {
   mock({
-    '/temporary/k6_tests/': {
-      'test1.js': `import http from 'k6/http';
+    "/temporary/k6_tests/": {
+      "test1.js": `import http from 'k6/http';
         import { check } from 'k6';
       
         export let options = {
@@ -14,11 +14,11 @@ beforeAll(() => {
             { target: 0, duration: '30s' },
           ],
         };`,
-        'test2.js': `export const options = {
+      "test2.js": `export const options = {
           vus: 10000,
           duration: '30s',
         };`,
-        'test3.js': `export const options = {
+      "test3.js": `export const options = {
           discardResponseBodies: true,
           scenarios: {
             contacts: {
@@ -30,10 +30,10 @@ beforeAll(() => {
               maxVUs: 3000,
             },
           },
-        };`
+        };`,
     },
-    'manifests/load_test_crds/': {
-      'k6_crd.yaml': `{
+    "manifests/load_test_crds/": {
+      "k6_crd.yaml": `{
         "apiVersion": "k6.io/v1alpha1",
         "kind": "K6",
         "metadata": {
@@ -94,8 +94,8 @@ beforeAll(() => {
             }
           }
         }
-      }`
-    }
+      }`,
+    },
   });
 });
 
@@ -103,38 +103,38 @@ afterAll(() => {
   mock.restore();
 });
 
-test('parses an integer that is embedded in a string containing other non-numerical characters and returns it as a number', () => {
+test("parses an integer that is embedded in a string containing other non-numerical characters and returns it as a number", () => {
   expect(manifest.findNumber("vus: 5000")).toBe(5000);
 });
 
-test('returns the larger of 2 given numbers, where one given number is embedded in a string', () => {
+test("returns the larger of 2 given numbers, where one given number is embedded in a string", () => {
   expect(manifest.maxNumVus(3000, "target: 4500")).toBe(4500);
 });
 
-test('base 64 encodes a value appropriately', () => {
+test("base 64 encodes a value appropriately", () => {
   expect(manifest.base64("test")).toBe("dGVzdA==");
 });
 
-test('calculates parallelism argument accurately with appropriate rounding', () => {
+test("calculates parallelism argument accurately with appropriate rounding", () => {
   expect(manifest.parallelism(10, 50)).toBe(1);
 });
 
-test('reads latest test id property accurately from k6 custom resource file', () => {
+test("reads latest test id property accurately from k6 custom resource file", () => {
   expect(manifest.latestK6TestId()).toBe(4);
 });
 
-test('discerns maximum number of vus accurately from test file containing multiple vu targets at different stages', () => {
-  expect(manifest.numVus('/temporary/k6_tests/test1.js')).toBe(600);
+test("discerns maximum number of vus accurately from test file containing multiple vu targets at different stages", () => {
+  expect(manifest.numVus("/temporary/k6_tests/test1.js")).toBe(600);
 });
 
-test('discerns maximum number of vus accurately from test file containing vus property', () => {
-  expect(manifest.numVus('/temporary/k6_tests/test2.js')).toBe(10000);
+test("discerns maximum number of vus accurately from test file containing vus property", () => {
+  expect(manifest.numVus("/temporary/k6_tests/test2.js")).toBe(10000);
 });
 
-test('discerns maximum number of vus accurately from test file containing maxVUs property', () => {
-  expect(manifest.numVus('/temporary/k6_tests/test3.js')).toBe(3000);
+test("discerns maximum number of vus accurately from test file containing maxVUs property", () => {
+  expect(manifest.numVus("/temporary/k6_tests/test3.js")).toBe(3000);
 });
 
-test('returns 0 maximum number of vus when test file cannot be found', () => {
-  expect(manifest.numVus('/temporary/k6_tests/test100.js')).toBe(0);
+test("returns 0 maximum number of vus when test file cannot be found", () => {
+  expect(manifest.numVus("/temporary/k6_tests/test100.js")).toBe(0);
 });

--- a/src/__tests__/cli/utilities/aws.js
+++ b/src/__tests__/cli/utilities/aws.js
@@ -1,0 +1,103 @@
+import aws from "../../../utilities/aws.js";
+
+const fakeAccountNum = "10000000001";
+const avZoneA = "us-west-2a";
+const avZoneB = "us-west-2b";
+const avZoneC = "us-west-2c";
+
+const invalidUserAVZoneInput =
+  `When specifying >1 availability zones, please ` +
+  `specify the desired zones as a comma separated list` +
+  ` like so: "us-east-1a,us-east-1b"`;
+
+const generatorNode = "m5.24xlarge";
+const aggregatorNode = "m5zn.large";
+const nodeOfferingsInRegion = `
+  +-----------------------------------------------------+
+  ||               InstanceTypeOfferings               ||
+  |+--------------+--------------+---------------------+|
+  || InstanceType |  Location    |    LocationType     ||
+  |+--------------+--------------+---------------------+|
+  ||  m5zn.large  |  us-west-2a  |  availability-zone  ||
+  ||  m5zn.large  |  us-west-2c  |  availability-zone  ||
+  ||  m5zn.large  |  us-west-2b  |  availability-zone  ||
+  |+--------------+--------------+---------------------+|
+`;
+
+jest.mock("util", () => ({
+  promisify: jest.fn(() => {
+    return jest.fn().mockResolvedValue({
+      stdout: `{
+          "UserId": fakeUserId,
+          "Account": "${fakeAccountNum}",
+          "Arn": arn:aws:iam::someNumber:someRole,
+        },
+        {
+          "ZoneName": ${avZoneA},
+          ...
+          "ZoneName": ${avZoneB},
+          ...
+          "ZoneName": ${avZoneC},
+        }`,
+    });
+  }),
+}));
+
+describe("Check logic that processes aws cli commands' inputs and outputs", () => {
+  test("Account id number should be extracted from aws sts get-caller-identity stdout", async () => {
+    await expect(aws.getAccountId()).resolves.toMatch(fakeAccountNum);
+  });
+
+  test("Availability zones are parsed accurately from stdout and set as object keys", async () => {
+    const zones = await aws.usersPossibleZones();
+    expect(zones).toHaveProperty(avZoneA);
+    expect(zones).toHaveProperty(avZoneB);
+    expect(zones).toHaveProperty(avZoneC);
+  });
+
+  test("Spaces are removed from test name & compressed file extension is added when deriving s3 upload name", () => {
+    const testName = "100k VUs";
+    expect(aws.s3ObjectNameForTest(testName)).toEqual("100kVUs.tar.gz");
+  });
+
+  test("True is returned when checking for existing AWS S3 Bucket", async () => {
+    await expect(aws.archiveBucketExists()).resolves.toEqual(true);
+  });
+
+  test("True is returned when checking for existing AWS S3 Object", async () => {
+    await expect(aws.s3ObjectExists()).resolves.toEqual(true);
+  });
+
+  test("Error is thrown when user doesn't list their desired availability zones in expected list format", () => {
+    expect.assertions(1);
+    try {
+      aws.checkForInvalidZoneList("us-west-2aus-west-2b");
+    } catch (error) {
+      expect(error.message).toEqual(invalidUserAVZoneInput);
+    }
+  });
+
+  test("Error is thrown when user doesn't specify availability zone names that align with AWS naming conventions", () => {
+    try {
+      aws.checkForInvalidZoneList("uswest2auswest2b");
+    } catch (error) {
+      expect(error.message).toEqual(invalidUserAVZoneInput);
+    }
+  });
+
+  test("Expect returned message to indicate availability of node type in region when AWS CLI stdout reflects the specified node", () => {
+    const message = aws.nodeTypeAvailableMsg(
+      nodeOfferingsInRegion,
+      aggregatorNode
+    );
+    expect(message).toMatch("generally available");
+  });
+
+  test("Expect returned message to indicate no availability of node type in region when AWS CLI stdout doesn't reflect the specified node", () => {
+    const message = aws.nodeTypeAvailableMsg(
+      nodeOfferingsInRegion,
+      generatorNode
+    );
+    expect(message).toMatch("not generally available");
+  });
+});

--- a/src/__tests__/cli/utilities/cluster.js
+++ b/src/__tests__/cli/utilities/cluster.js
@@ -1,0 +1,127 @@
+import cluster from "../../../utilities/cluster.js";
+import aws from "../../../utilities/aws.js";
+import iam from "../../../utilities/iam.js";
+import eksctl from "../../../utilities/eksctl.js";
+import files from "../../../utilities/files.js";
+import kubectl from "../../../utilities/kubectl.js";
+import manifest from "../../../utilities/manifest.js";
+import { K6_CR_FILE } from "../../../constants/constants.js";
+import loadGenerators from "../../../utilities/loadGenerators.js";
+import dbApi from "../../../utilities/dbApi.js";
+
+jest.mock("../../../utilities/files.js", () => ({
+  delete: jest.fn(() => {}),
+  path: jest.fn(() => {}),
+}));
+
+jest.mock("../../../utilities/dbApi.js", () => ({
+  logUrl: jest.fn(() => {}),
+}));
+
+jest.mock("../../../utilities/iam.js", () => ({
+  deleteAWSLbcPolArn: jest.fn(() => {}),
+  ebsRole: jest.fn(() => {
+    return "example role";
+  }),
+  OIDCexists: jest.fn(() => {
+    return { stdout: "" };
+  }),
+}));
+
+jest.mock("../../../utilities/eksctl.js", () => ({
+  destroyCluster: jest.fn(() => {}),
+  scaleNodes: jest.fn(() => {}),
+  addCsiDriver: jest.fn(() => {}),
+  addIAMDriverRole: jest.fn(() => {}),
+  fetchIamRoles: jest.fn(() => {
+    return { stdout: "" };
+  }),
+  createOIDC: jest.fn(() => {}),
+}));
+
+jest.mock("../../../utilities/manifest.js", () => ({
+  forEachGrafJsonDB: jest.fn(() => {}),
+  latestK6TestId: jest.fn(() => {
+    return "1";
+  }),
+}));
+
+jest.mock("../../../utilities/loadGenerators.js", () => ({
+  pollUntilGenNodesScaleDown: jest.fn(() => {}),
+}));
+
+jest.mock("../../../utilities/kubectl.js", () => ({
+  configMapExists: jest.fn(() => {
+    return false;
+  }),
+  createConfigMap: jest.fn(() => {}),
+  createConfigMapWithName: jest.fn(() => {}),
+  deployK6Operator: jest.fn(() => {}),
+  applyManifest: jest.fn(() => {}),
+  deleteManifest: jest.fn(() => {}),
+  deleteConfigMap: jest.fn(() => {}),
+  getCrds: jest.fn(() => {
+    return { stdout: "" };
+  }),
+  getPods: jest.fn(() => {
+    return { stdout: "" };
+  }),
+}));
+
+jest.mock("../../../utilities/aws.js", () => ({
+  deleteOldIamLBCPolicy: jest.fn(() => {}),
+  deleteEBSVolumes: jest.fn(() => {}),
+  fetchOIDCs: jest.fn(() => {
+    return { stdout: "" };
+  }),
+}));
+
+test("Expect final node group files, IAM LBC policy, EBS Volumes, and cluster to all be deleted when destroy is called", async () => {
+  await cluster.destroy();
+  expect(aws.deleteOldIamLBCPolicy).toBeCalled();
+  expect(aws.deleteEBSVolumes).toBeCalled();
+  expect(iam.deleteAWSLbcPolArn).toBeCalled();
+  expect(files.delete).toBeCalled();
+  expect(eksctl.destroyCluster).toBeCalled();
+});
+
+test("Expect grafana manifests to be applied if grafana configmap doesn't exist yet", async () => {
+  await cluster.applyGrafanaManifests();
+  expect(kubectl.createConfigMapWithName).toHaveBeenCalledTimes(2);
+  expect(kubectl.createConfigMapWithName).toHaveBeenCalledWith(
+    "grafana-datasources",
+    undefined
+  );
+  expect(manifest.forEachGrafJsonDB).toBeCalled();
+  expect(kubectl.applyManifest).toBeCalled();
+});
+
+test("Expect statsite manifest to be applied if statsite configmap doesn't exist yet", async () => {
+  await cluster.applyStatsiteManifests();
+  expect(kubectl.createConfigMapWithName).toBeCalled();
+});
+
+test("Expect load aggregating and generating nodes, manifests, and k6 custom resource to be deleted when load test resources are torn down", async () => {
+  await cluster.phaseOutK6();
+  expect(manifest.latestK6TestId).toBeCalled();
+  expect(kubectl.deleteManifest).toHaveBeenCalledTimes(2);
+  expect(kubectl.deleteConfigMap).toBeCalled();
+  expect(kubectl.deleteConfigMap).toHaveBeenCalledWith("1");
+  expect(eksctl.scaleNodes).toHaveBeenCalledTimes(2);
+  expect(loadGenerators.pollUntilGenNodesScaleDown).toBeCalled();
+  expect(files.delete).toHaveBeenCalledWith(K6_CR_FILE);
+});
+
+test("Expect configmap and manifests to be applied when a k6 load test is launched", async () => {
+  await cluster.launchK6Test("/some/path", 1);
+  expect(kubectl.applyManifest).toHaveBeenCalledTimes(3);
+  expect(kubectl.createConfigMapWithName).toBeCalled();
+});
+
+test("Expect oidc provider to be created if one doesn't exist for configuring EBS volumes", async () => {
+  await cluster.configureEBSCreds();
+  expect(eksctl.addIAMDriverRole).toBeCalled();
+  expect(eksctl.fetchIamRoles).toBeCalled();
+  expect(iam.ebsRole).toBeCalled();
+  expect(eksctl.addCsiDriver).toBeCalled();
+});

--- a/src/__tests__/cli/utilities/eksctl.js
+++ b/src/__tests__/cli/utilities/eksctl.js
@@ -1,0 +1,44 @@
+import eksctl from "../../../utilities/eksctl.js";
+import aws from "../../../utilities/aws.js";
+
+jest.mock("../../../utilities/aws.js", () => ({
+  throwErrorIfInvalidZone: jest.fn(() => {}),
+}));
+
+jest.mock("util", () => ({
+  promisify: jest.fn(() => {
+    return jest.fn().mockResolvedValue({
+      stdout: `
+        NAME	REGION		EKSCTL CREATED\n
+        edamame	us-west-2	True
+      `,
+    });
+  }),
+}));
+
+test("Error is not thrown when eksctl is installed", async () => {
+  expect.assertions(0);
+  try {
+    await eksctl.existsOrError();
+  } catch (error) {
+    expect(error.message).toMatch(
+      "Eksctl isn't installed. Please install eksctl;"
+    );
+  }
+});
+
+test("Region is parsed accurately from eksctl command's get cluster info stdout", async () => {
+  const region = await eksctl.getRegion();
+  expect(region).toBe("us-west-2");
+});
+
+test("Expect availability zone validation function to not be called if user provides a list of zones", async () => {
+  await eksctl.createCluster();
+  expect(aws.throwErrorIfInvalidZone).not.toBeCalled();
+});
+
+test("Expect availability zone validation function to be called if user provides a list of zones", async () => {
+  const zones = "us-west-2a,us-west-2b";
+  await eksctl.createCluster(zones);
+  expect(aws.throwErrorIfInvalidZone).toHaveBeenCalledWith(zones);
+});

--- a/src/__tests__/cli/utilities/helm.js
+++ b/src/__tests__/cli/utilities/helm.js
@@ -1,0 +1,18 @@
+import helm from "../../../utilities/helm.js";
+
+jest.mock("util", () => ({
+  promisify: jest.fn(() => {
+    return jest.fn().mockResolvedValue({
+      stdout: "",
+    });
+  }),
+}));
+
+test("Error is thrown if helm is installed", async () => {
+  expect.assertions(1);
+  try {
+    await helm.existsOrError();
+  } catch (error) {
+    expect(error.message).toMatch("Helm isn't installed. Please install helm");
+  }
+});

--- a/src/__tests__/cli/utilities/iam.js
+++ b/src/__tests__/cli/utilities/iam.js
@@ -1,0 +1,38 @@
+import iam from "../../../utilities/iam.js";
+import files from "../../../utilities/files.js";
+
+jest.mock("../../../utilities/files.js", () => ({
+  write: jest.fn(() => {}),
+}));
+
+const fakeId = "1000000100";
+const csiDriver = "arn:aws:iam::SOME_ACCOUNT:role/AmazonEKS_EBS_CSI_DriverRole";
+const iamRoleStdout = `NAMESPACE	NAME  ROLE ARN\nebs-csi-controller-sa\t${csiDriver}`;
+
+const validOidcList = `SOME_NUMBER\n OpenIDConnectProviderList: [{ "Arn": "arn:aws:iam::SOME_ACCOUNT:oidc-provider/id/SOME_NUMBER" }]`;
+const invalidOidcList = `SOME_NUMBER OpenIDConnectProviderList: [{ "Arn": "arn:aws:iam::SOME_ACCOUNT:oidc-provider/id/SOME_OTHER_NUMBER" }]`;
+
+describe("Check logic that processes iam related cli commands' inputs and outputs", () => {
+  test("Undefined is returned if eksctl stdout doesn't match EBS CSI driver", () => {
+    expect(iam.ebsRole("")).toEqual(undefined);
+  });
+
+  test("EBS CSI driver string role is returned if eksctl stdout matches expected role syntax", () => {
+    expect(iam.ebsRole(iamRoleStdout)).toEqual(csiDriver);
+  });
+
+  test("Expect file to be written when logging AWS lbc policy arn from stdout", () => {
+    iam.logAWSLbcPolArn("some policy info");
+    expect(files.write).toBeCalled();
+  });
+
+  test("Expect true to be returned when stdout shows existing OIDC provider arn", () => {
+    const exists = iam.OIDCexists(validOidcList);
+    expect(exists).toEqual(true);
+  });
+
+  test("Expect false to be returned when stdout doesn't show existing OIDC provider arn", () => {
+    const exists = iam.OIDCexists(invalidOidcList);
+    expect(exists).toEqual(false);
+  });
+});

--- a/src/__tests__/cli/utilities/kubectl.js
+++ b/src/__tests__/cli/utilities/kubectl.js
@@ -1,0 +1,48 @@
+import kubectl from "../../../utilities/kubectl.js";
+
+const exampleNodeDetails =
+  "ip-#.us-west.compute.internal   Ready    <none>   79m   v#-#";
+const grafanaConfigmap = "grafana-dashboards";
+
+jest.mock("util", () => ({
+  promisify: jest.fn(() => {
+    return jest.fn().mockResolvedValue({
+      stdout: `NAME STATUS ROLES AGE VERSION\n${exampleNodeDetails}\n${exampleNodeDetails}${grafanaConfigmap}`,
+    });
+  }),
+}));
+
+describe("Check logic that processes kubectl related cli commands' inputs and outputs", () => {
+  test("Expect nodes to parsed accurately from kubectl command's stdout", async () => {
+    const nodes = await kubectl.getLoadNodes("ng-agg");
+    expect(nodes[0]).toMatch(exampleNodeDetails);
+    expect(nodes[1]).toMatch(exampleNodeDetails);
+    expect(nodes.length).toEqual(2);
+  });
+
+  test("Error isn't thrown if kubectl is installed", async () => {
+    expect.assertions(0);
+    try {
+      await kubectl.existsOrError();
+    } catch (error) {
+      expect(error.message).toMatch(
+        "Kubectl isn't installed. Please install it"
+      );
+    }
+  });
+
+  test("False is returned if specified configmap name isn't found in existing configmaps stdout", async () => {
+    const result = await kubectl.configMapExists("statsite-config");
+    expect(result).toEqual(false);
+  });
+
+  test("True is returned if specified configmap name is found in existing configmaps stdout", async () => {
+    const result = await kubectl.configMapExists(grafanaConfigmap);
+    expect(result).toEqual(true);
+  });
+
+  test("Expect 2 to be returned when parsing kubectl stdout that shows 2 ready nodes", async () => {
+    const result = await kubectl.getLoadNodesReadyCount("ng-agg");
+    expect(result).toEqual(2);
+  });
+});

--- a/src/__tests__/cli/utilities/loadGenerators.js
+++ b/src/__tests__/cli/utilities/loadGenerators.js
@@ -1,0 +1,23 @@
+import loadGenerators from "../../../utilities/loadGenerators.js";
+import kubectl from "../../../utilities/kubectl.js";
+
+jest.mock("../../../utilities/kubectl.js", () => ({
+  getPods: jest.fn(() => {
+    return {
+      stdout: `NAME          READY   STATUS    RESTARTS      AGE
+        k6-edamame-test-12034  1/1     Completed   1 (90m ago)   90m
+        k6-edamame-test-3023   1/1     Completed   0             90m
+        k6-edamame-test-23403  1/1     Completed   0             90m`,
+    };
+  }),
+}));
+
+test("True is returned when all pods are completed and stdout is processed appropriately", async () => {
+  const result = await loadGenerators.checkAllCompleted(3);
+  expect(result).toEqual(true);
+});
+
+test("Falsey value is returned when the expected number of pods aren't shown as completed in stdout", async () => {
+  const result = await loadGenerators.checkAllCompleted(4);
+  expect(!!result).toEqual(false);
+});

--- a/src/commands/archiveContents.js
+++ b/src/commands/archiveContents.js
@@ -1,0 +1,24 @@
+import aws from "../utilities/aws.js";
+import Spinner from "../utilities/spinner.js";
+import archiveMessage from "../utilities/archiveMessage.js";
+
+const showArchiveContents = async () => {
+  const spinner = new Spinner(archiveMessage.startDisplay);
+
+  try {
+    let s3Objects = await aws.listObjectsInS3Bucket();
+    if (s3Objects.length === 0) {
+      spinner.succeed(archiveMessage.emptyBucket);
+    } else {
+      spinner.succeed(archiveMessage.display(s3Objects));
+    }
+  } catch (err) {
+    if (err.stderr && err.stderr.match("NoSuchBucket")) {
+      spinner.fail(archiveMessage.noBucket);
+    } else {
+      spinner.fail(archiveMessage.error(err, "display"));
+    }
+  }
+};
+
+export { showArchiveContents };

--- a/src/commands/importFromArchive.js
+++ b/src/commands/importFromArchive.js
@@ -1,0 +1,70 @@
+import aws from "../utilities/aws.js";
+import dbApi from "../utilities/dbApi.js";
+import Spinner from "../utilities/spinner.js";
+import archiveMessage from "../utilities/archiveMessage.js";
+
+const singleImport = async (testName, spinner) => {
+  try {
+    const response = await dbApi.archive("import", testName);
+    if (response.success) {
+      spinner.info(response.success);
+    }
+  } catch (err) {
+    const duplicate =
+      err.response && err.response.data && err.response.data.error;
+
+    const message = duplicate
+      ? archiveMessage.duplicateImport(testName)
+      : archiveMessage.singleImportFail(testName);
+
+    spinner.info(message);
+  }
+};
+
+const s3ObjectsToImport = async (testName) => {
+  let imports;
+  if (testName !== undefined) {
+    const bucketExists = await aws.archiveBucketExists();
+    if (!bucketExists) throw Error("NoSuchBucket");
+
+    const testExists = aws.s3ObjectExists(aws.s3ObjectNameForTest(testName));
+    if (!testExists) throw Error(archiveMessage.noObject(testName));
+
+    imports = [testName];
+  } else {
+    let s3Objects = await aws.listObjectsInS3Bucket();
+    imports = s3Objects.map((obj) => obj.split(".")[0]);
+  }
+  return imports;
+};
+
+const importFromArchive = async (options) => {
+  const spinner = new Spinner(archiveMessage.startImport);
+  const testName = options.name;
+
+  try {
+    const s3Objects = await s3ObjectsToImport(testName);
+    for (let i = 0; i < s3Objects.length; i++) {
+      await singleImport(s3Objects[i], spinner);
+    }
+    if (s3Objects.length > 0) {
+      spinner.succeed(archiveMessage.importComplete);
+    } else {
+      spinner.succeed(`No imports; ${archiveMessage.emptyBucket}`);
+    }
+  } catch (err) {
+    processImportError(err, spinner);
+  }
+};
+
+const processImportError = (error, spinner) => {
+  if (error.message.match("NoSuchBucket")) {
+    spinner.fail(archiveMessage.noBucket);
+  } else if (error.message.match("No s3 object")) {
+    spinner.fail(error.message);
+  } else {
+    spinner.fail(archiveMessage.error(error, "import"));
+  }
+};
+
+export { importFromArchive };

--- a/src/index.js
+++ b/src/index.js
@@ -16,13 +16,18 @@ import { Command } from "commander";
 import { startGui, stopGui } from "./commands/gui.js";
 import { archive } from "./commands/archive.js";
 import { deleteFromArchive } from "./commands/deleteFromArchive.js";
+import { importFromArchive } from "./commands/importFromArchive.js";
+import { showArchiveContents } from "./commands/archiveContents.js";
 import { ARCHIVE } from "./constants/constants.js";
 
 const program = new Command();
 
 program
   .command("init")
-  .option("-z, --zones <zones>", "List of one or more desired cluster availability zones specific to a user's preferred aws region")
+  .option(
+    "-z, --zones <zones>",
+    "List of one or more desired cluster availability zones specific to a user's preferred aws region"
+  )
   .description(
     "Create an EKS cluster and deploy Grafana, Postgres, & K6 Operator"
   )
@@ -104,19 +109,47 @@ program
 
 program
   .command("archive")
-  .option("--all", `Upload all load tests as S3 Objects to the ${ARCHIVE} AWS S3 Bucket`)
+  .option(
+    "--all",
+    `Upload all load tests as S3 Objects to the ${ARCHIVE} AWS S3 Bucket`
+  )
   .option("-n, --name <name>", "Name of specific test to archive")
   .description(
     `Move load test data from EBS volume to AWS S3 Glacier to allow for persistent test ` +
-    ` data storage beyond the life of the Edamame EKS cluster. If test name flag isn't ` +
-    ` provided, then all existing test data will be archived. `
-  ).action(archive);
+      ` data storage beyond the life of the Edamame EKS cluster. If test name flag isn't ` +
+      ` provided, then all existing test data will be archived. `
+  )
+  .action(archive);
 
 program
   .command("delete-from-archive")
   .option("--all", `Delete entire ${ARCHIVE} AWS S3 Bucket`)
-  .option("-n, --name <name>", "Name of specific test to remove from the AWS S3 Bucket")
-  .description(`Delete specific load test from the ${ARCHIVE} AWS S3 Bucket or delete the entire bucket`)
+  .option(
+    "-n, --name <name>",
+    "Name of specific test to remove from the AWS S3 Bucket"
+  )
+  .description(
+    `Delete specific load test from the ${ARCHIVE} AWS S3 Bucket or delete the entire bucket`
+  )
   .action(deleteFromArchive);
+
+program
+  .command("import-from-archive")
+  .option("--all", `Import all data stored in the ${ARCHIVE} AWS S3 Bucket`)
+  .option(
+    "-n, --name <name>",
+    "Name of specific test to import from the AWS S3 Bucket"
+  )
+  .description(
+    `Imports historical load test data stored in ${ARCHIVE} AWS S3 Bucket to the Postgres database`
+  )
+  .action(importFromArchive);
+
+program
+  .command("archive-contents")
+  .description(
+    `List the names of the historical load tests that exist in the AWS S3 Bucket`
+  )
+  .action(showArchiveContents);
 
 program.parse(process.argv);

--- a/src/utilities/archiveMessage.js
+++ b/src/utilities/archiveMessage.js
@@ -1,0 +1,100 @@
+import files from "./files.js";
+
+const archiveMessage = {
+  noTests: "There are no tests to archive",
+
+  start: "Starting archive process...",
+
+  bucketReady: "AWS S3 Bucket is ready for uploads.",
+
+  noBucket: "There's no AWS S3 bucket containing load tests.",
+
+  startDisplay: "Loading AWS S3 Bucket archive details...",
+
+  startImport:
+    "Starting process to import AWS S3 archived data into Postgres database...",
+
+  emptyBucket: "Your AWS S3 Edamame load test bucket is empty.",
+
+  deletedBucket: "Deleted Edamame load test AWS S3 bucket",
+
+  startDeletion: "Starting archival deletion process...",
+
+  importComplete: "Completed importing data from AWS S3.",
+
+  exportComplete: "Archive process complete.",
+
+  nonexistentTest(testName) {
+    return `Nonexistent test to archive: ${testName}.`;
+  },
+
+  alreadyExists(name) {
+    return `Archive for ${name} already exists. Skipping to next step.`;
+  },
+
+  uploadSuccess(name) {
+    return `Successfully archived ${name}.`;
+  },
+
+  sizeIssue(testName) {
+    return (
+      `There was an issue archiving your load test: ${testName}.` +
+      ` It seems your load test had enough data to exceed the` +
+      ` upload size limit. Please reach out to an Edamame` +
+      ` developer for a custom archive solution for this test.`
+    );
+  },
+
+  display(s3Contents) {
+    return (
+      `Your Edamame load test AWS S3 Bucket contains ` +
+      `the following load test S3 objects:\n > ${s3Contents.join("\n > ")}`
+    );
+  },
+
+  duplicateImport(testName) {
+    return (
+      `AWS S3 archive data for ${testName} overlaps with existing` +
+      ` data in the database. Can't import duplicate information.`
+    );
+  },
+
+  error(errorInfo, type) {
+    let msg;
+    if (type === "upload") {
+      msg = `Error archiving load test data: \n${errorInfo}`;
+    } else if (type === "delete") {
+      msg = `Error deleting load test data from AWS S3 storage: \n${errorInfo}`;
+    } else if (type === "display") {
+      msg = `Error retrieving details about your AWS S3 Bucket: \n${errorInfo}`;
+    } else {
+      msg = `Error importing load test data from archive into cluster database: \n${errorInfo}`;
+    }
+    return msg;
+  },
+
+  noObject(testName) {
+    return `No s3 object associated with the test named ${testName}.`;
+  },
+
+  singleDeletionSuccess(name) {
+    return `Successfully deleted ${name} from your Edamame load test AWS S3 Bucket.`;
+  },
+
+  singleImportFail(name) {
+    return `Issue importing ${testName}. Please try again later.`;
+  },
+
+  createBucketInRegion() {
+    const region = files
+      .read(files.path("postgres.env"))
+      .match("aws-region=.{1,}\n")[0];
+
+    return (
+      `Creating load test AWS S3 Bucket ` +
+      `located in: ${region} if it doesn't exist yet...`
+    );
+  },
+};
+
+export default archiveMessage;

--- a/src/utilities/aws.js
+++ b/src/utilities/aws.js
@@ -1,4 +1,4 @@
-import { 
+import {
   AWS_LBC_IAM_POLNAME,
   CLUSTER_NAME,
   ARCHIVE,
@@ -17,7 +17,9 @@ const aws = {
     const { stdout } = await exec(`aws cloudformation describe-stacks`);
     stdout.split("\n").forEach(async (line) => {
       if (line.match(`"StackName": "eksctl-edamame`)) {
-        let stackName = line.split(`"`).filter(part => part.match("edamame"))[0];
+        let stackName = line
+          .split(`"`)
+          .filter((part) => part.match("edamame"))[0];
         await exec(`aws cloudformation delete-stack --stack-name ${stackName}`);
       }
     });
@@ -40,32 +42,37 @@ const aws = {
     }
 
     if (invalid) {
-      let msg = `One of your specified zones, ` +
-        `${invalidZone}, isn't in the list of aws ` +
-        `availability zones for your region`;
+      let msg =
+        `One of your specified zones, ${invalidZone}, isn't in ` +
+        `the list of aws availability zones for your region`;
       throw Error(msg);
     }
   },
 
   checkForInvalidZoneList(zones) {
-    let numDashes = zones.split("").filter(char => char === "-").length;
-    if (!zones.match(",") && numDashes >= MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES) {
-      let msg = `When specifying >1 availability zones, please ` +
+    let numDashes = zones.split("").filter((char) => char === "-").length;
+    if (
+      !zones.match(",") &&
+      numDashes >= MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES
+    ) {
+      let msg =
+        `When specifying >1 availability zones, please ` +
         `specify the desired zones as a comma separated list` +
         ` like so: "us-east-1a,us-east-1b"`;
-      throw Error (msg);
+      throw Error(msg);
     }
   },
 
   async usersPossibleZones() {
-    const command = `aws ec2 describe-availability-zones` +
-      ` --all-availability-zones`;
+    const command = `aws ec2 describe-availability-zones --all-availability-zones`;
     const { stdout } = await exec(command);
-    let zones = stdout.split("\n").filter(line => line.match(`"ZoneName"`));
+    let zones = stdout.split("\n").filter((line) => line.match(`"ZoneName"`));
     let zonesLookup = {};
 
-    zones.forEach(zoneDesc => {
-      let zoneKey = zoneDesc.split(`"ZoneName": `).filter(info => info !== "")[1];
+    zones.forEach((zoneDesc) => {
+      let zoneKey = zoneDesc
+        .split(`"ZoneName": `)
+        .filter((info) => info !== "")[1];
       zoneKey = zoneKey.replace(",", "").replaceAll(`"`, "");
       zonesLookup[zoneKey] = zoneDesc;
     });
@@ -79,8 +86,8 @@ const aws = {
 
     const { stdout } = await exec(
       `cd ${files.path("")} && aws iam create-policy ` +
-      `--policy-name ${AWS_LBC_IAM_POLNAME} ` +
-      "--policy-document file://iam_policy.json"
+        `--policy-name ${AWS_LBC_IAM_POLNAME} ` +
+        "--policy-document file://iam_policy.json"
     );
     const policyArn = iam.lbcPolicyArn(stdout);
     await eksctl.createIamRoleLBCPol(policyArn);
@@ -100,9 +107,7 @@ const aws = {
 
   deleteOldIamLBCPolicy(policy) {
     if (policy) {
-      return exec(
-        `aws iam delete-policy --policy-arn ${policy}`
-      );
+      return exec(`aws iam delete-policy --policy-arn ${policy}`);
     }
   },
 
@@ -111,37 +116,48 @@ const aws = {
     const region = nodeGroupData.metadata.region;
 
     const { stdout } = await this.describeInstanceTypes(nodeType, region);
-    let msg = `Edamame has checked the instance types available in your ` +
+    let msg =
+      `Edamame has checked the instance types available in your ` +
       `AWS region, ${region}, and the ${nodeType} nodes are`;
 
+    console.log(`${msg} ${this.nodeTypeAvailableMsg(stdout)}`);
+  },
+
+  nodeTypeAvailableMsg(stdout, nodeType) {
+    let msg;
     if (stdout.match(nodeType)) {
-      console.log(`${msg} generally available:`);
-      console.log(stdout);
-      console.log("If you initialized the Edamame cluster with the optional --zones " +
-        "flag, please double check that you specified at least one of the availability " +
-        "zones shown in the table output above.");
-      console.log("Otherwise, please try executing your load test again later, " +
-        "as the required AWS instance types should become available again.");
+      msg =
+        `generally available:\n ${stdout} \n If you ` +
+        "initialized the Edamame cluster with the optional " +
+        "--zones flag, please double check that you specified " +
+        "at least one of the availability zones shown in the " +
+        "table output above. Otherwise, please try executing " +
+        "your load test again later, as the required AWS " +
+        "instance types should become available again.";
     } else {
-      console.log(`${msg} not generally available:`);
-      console.log(stdout);
-      console.log(`Please switch AWS regions or contact Edamame developers, so ` +
-        `that we can extend Edamame's options for you region's specialized needs.`);
+      msg =
+        `not generally available:\n ${stdout} \n` +
+        ` Please switch AWS regions or contact Edamame` +
+        ` developers, so that we can extend Edamame's` +
+        ` options for you region's specialized needs.`;
     }
+    return msg;
   },
 
   async describeInstanceTypes(nodeType, region) {
-    const command = `aws ec2 describe-instance-type-offerings ` +
+    const command =
+      `aws ec2 describe-instance-type-offerings ` +
       `--location-type availability-zone ` +
       `--filters Name=instance-type,` +
-      `Values=${nodeType} --region ${region} `+
+      `Values=${nodeType} --region ${region} ` +
       `--output table`;
 
     return exec(command);
   },
 
   async deleteEBSVolumes() {
-    let volumesCommand = `aws ec2 describe-volumes --filter ` +
+    let volumesCommand =
+      `aws ec2 describe-volumes --filter ` +
       `"Name=tag:kubernetes.io/created-for/pvc/name,` +
       `Values=data-postgres-0,grafana-pvc" --query` +
       ` 'Volumes[].VolumeId' --output json`;
@@ -162,21 +178,21 @@ const aws = {
   },
 
   async getAccountId() {
-    const { stdout } = await exec('aws sts get-caller-identity');
+    const { stdout } = await exec("aws sts get-caller-identity");
     let accountId = stdout.match(/Account": .{1,}"/)[0];
     return accountId.split(": ")[1];
   },
 
   async currentCLICredentials() {
-    let region = await this.getConfiguration('region');
+    let region = await this.getConfiguration("region");
     let accountId = await this.getAccountId();
-    let accessKey = await this.getConfiguration('aws_access_key_id');
-    let secretKey = await this.getConfiguration('aws_secret_access_key');
+    let accessKey = await this.getConfiguration("aws_access_key_id");
+    let secretKey = await this.getConfiguration("aws_secret_access_key");
     return {
       region,
       accountId,
       accessKey,
-      secretKey
+      secretKey,
     };
   },
 
@@ -187,14 +203,15 @@ const aws = {
     } catch (error) {
       if (error.stderr.match("NoSuchBucket")) {
         return false;
-      } else { // unknown error; abort process
+      } else {
+        // unknown error; abort process
         throw Error(error);
       }
     }
   },
 
   s3ObjectNameForTest(testName) {
-    return `${testName.replaceAll("-", "")}.tar.gz`;
+    return `${testName.replaceAll(" ", "")}.tar.gz`;
   },
 
   async s3ObjectExists(file) {
@@ -202,12 +219,26 @@ const aws = {
       await exec(`aws s3api head-object --bucket ${ARCHIVE} --key ${file}`);
       return true;
     } catch (error) {
-      if (error.stderr.match("Not Found")) { // file doesn't exist yet
+      if (error.stderr.match("Not Found")) {
+        // file doesn't exist yet
         return false;
-      } else { // unknown error; abort process
+      } else {
+        // unknown error; abort process
         throw Error(error);
       }
     }
+  },
+
+  async listObjectsInS3Bucket() {
+    const { stdout } = await exec(`aws s3 ls s3://${ARCHIVE} --recursive`);
+    const fileNames = [];
+    stdout.split("\n").forEach((line) => {
+      if (line) {
+        const fileDetails = line.split(/\s/);
+        fileNames.push(fileDetails[fileDetails.length - 1]);
+      }
+    });
+    return fileNames;
   },
 
   async setUpArchiveBucket() {

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -3,13 +3,14 @@ import {
   EXTERNAL_IP_REGEX,
   DB_API_INGRESS_NAME,
   DISPLAY_TESTS_NUM_DASHES,
-  DISPLAY_TEST_TITLE_SPACES
+  DISPLAY_TEST_TITLE_SPACES,
 } from "../constants/constants.js";
 import manifest from "./manifest.js";
 import kubectl from "./kubectl.js";
 import eksctl from "./eksctl.js";
 import files from "./files.js";
 import axios from "axios";
+import aws from "./aws.js";
 
 const dbApi = {
   async nameExists(name) {
@@ -32,7 +33,10 @@ const dbApi = {
       const test = testData[i];
       if (attribute === "testName" && test.name === comparisonValue) {
         return true;
-      } else if (attribute === "status" && test.status.match(/(running|status)/)) {
+      } else if (
+        attribute === "status" &&
+        test.status.match(/(running|status)/)
+      ) {
         return true;
       }
     }
@@ -106,9 +110,9 @@ const dbApi = {
     console.log(`${spaces} Test script content: ${spaces}`);
     console.log(`${"-".repeat(DISPLAY_TESTS_NUM_DASHES)}`);
 
-    test.script.split("\\n").forEach(line => {
+    test.script.split("\\n").forEach((line) => {
       console.log(line);
-    });  
+    });
   },
 
   printTestDataTable(tests) {
@@ -193,20 +197,19 @@ const dbApi = {
     }
   },
 
-  async archiveTest(testName) {
-    const url = `${this.url()}/archive/${testName}`;
+  async archive(archivePath, testName) {
+    const url = `${this.url()}/${archivePath}/${testName}`;
 
     try {
-      let response = await axios.post(`${url}`, {});
+      let response = await axios.post(url, {});
       return response.data;
     } catch {
       await this.restoreIp();
-      const newUrl = `${this.url()}/archive/${testName}`;
-      let res = await axios.post(`${newUrl}`, {});
+      const newUrl = `${this.url()}/${archivePath}/${testName}`;
+      let res = await axios.post(newUrl, {});
       return res.data;
     }
-  }
-
+  },
 };
 
 export default dbApi;

--- a/src/utilities/eksctl.js
+++ b/src/utilities/eksctl.js
@@ -9,7 +9,7 @@ import {
   GEN_NODE_GROUP_TEMPLATE,
   AGG_NODE_GROUP_TEMPLATE,
   LOAD_GEN_NODE_GRP,
-  STATSITE_NODE_GRP
+  STATSITE_NODE_GRP,
 } from "../constants/constants.js";
 const exec = promisify(child_process.exec);
 
@@ -18,9 +18,10 @@ const eksctl = {
     try {
       await exec(`eksctl version`);
     } catch {
-      const msg = `Eksctl isn't installed. Please install eksctl; ` +
-      `instructions can be found at: ` +
-      `https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html`;
+      const msg =
+        `Eksctl isn't installed. Please install eksctl; ` +
+        `instructions can be found at: ` +
+        `https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html`;
       throw new Error(msg);
     }
   },
@@ -50,24 +51,16 @@ const eksctl = {
     } else {
       type = STATSITE_NODE_GRP;
       template = AGG_NODE_GROUP_TEMPLATE;
-    } 
-    await manifest.createNodeGroupCr(type, finalFile, template, useBackUpNodeType);
-    return exec(`eksctl create nodegroup --config-file ${files.path(finalFile)}`);
-  },
-
-  async deleteNodeGroup(type) {
-    const nodeGroupData = files.readYAML(GEN_NODE_GROUP_FILE);
-    const region = nodeGroupData.metadata.region;
-
-    let deleteCommand = `eksctl delete nodegroup ` +
-      ` --cluster ${CLUSTER_NAME} ` +
-      `--region ${region} --name `;
-   
-    if (type === LOAD_GEN_NODE_GRP) {
-      await exec(deleteCommand + LOAD_GEN_NODE_GRP);
-    } else {
-      await exec(deleteCommand + STATSITE_NODE_GRP);
     }
+    await manifest.createNodeGroupCr(
+      type,
+      finalFile,
+      template,
+      useBackUpNodeType
+    );
+    return exec(
+      `eksctl create nodegroup --config-file ${files.path(finalFile)}`
+    );
   },
 
   fetchIamRoles() {
@@ -134,7 +127,7 @@ const eksctl = {
     const { stdout } = await exec(`eksctl get cluster --verbose 0`);
     const line = stdout.split("\n").find((line) => line.includes("edamame"));
     return line.split("\t")[1];
-  }
+  },
 };
 
 export default eksctl;

--- a/src/utilities/iam.js
+++ b/src/utilities/iam.js
@@ -1,8 +1,8 @@
-import { 
+import {
   EBS_CSI_DRIVER_REGEX,
-  AWS_LBC_POLICY_REGEX
- } from "../constants/constants.js";
- import files from "./files.js";
+  AWS_LBC_POLICY_REGEX,
+} from "../constants/constants.js";
+import files from "./files.js";
 
 const iam = {
   deleteAWSLbcPolArn() {
@@ -44,8 +44,7 @@ const iam = {
   logAWSLbcPolArn(policy) {
     const data = `alb_pol_arn=${policy}\n`;
     files.write(".env", data);
-  }
+  },
 };
 
 export default iam;
-


### PR DESCRIPTION
…ing load tests from AWS S3

Specifically:
- add CLI command to show the current load test S3 object(s) in the user's AWS S3 load test bucket if it exists, to give the user local visibility into what's been archived so far
- add CLI command to import one or more AWS S3 load test objects in case the cluster is torn down for a period of time
- update logic underlying CLI commands to archive or delete from archive one or more tests to AWS S3 to reflect that tests with spaces in their name will have those spaces removed from their upload filename (when checking to make sure test hasn't already been uploaded yet to avoid duplicate uploads)
- add additional tests
- update readme for new CLI commands 