### PR TITLE
s3 flexible storage class selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ In order to execute a load test with the `edamame` command line interface or gra
 
 ### edamame init
 
-Usage: `edamame init --zones <comma_separated_list_of_desired_availability_zones_in_your_preferred_aws_region>`
-Example: `edamame init --zones us-west-2a,us-west-2b,us-west-2d`
+Usage: `edamame init --zones <comma_separated_list_of_desired_availability_zones_in_your_preferred_aws_region>` <br />
+Example: `edamame init --zones us-west-2a,us-west-2b,us-west-2d` <br />
 Outputs:
 
 ```
@@ -51,8 +51,8 @@ Outputs:
 
 ### edamame run
 
-Usage: `edamame run --file {/path/to/test.js} --name "<desired name>" --vus-per-pod <num_vus>`
-Alternative usage:`edamame run -f {/path/to/test.js} -n "<desired name>" -v <num_vus>`
+Usage: `edamame run --file {/path/to/test.js} --name "<desired name>" --vus-per-pod <num_vus>` <br />
+Alternative usage:`edamame run -f {/path/to/test.js} -n "<desired name>" -v <num_vus>` <br />
 Outputs:
 
 ```
@@ -81,7 +81,7 @@ Outputs:
 
 ### edamame stop
 
-Usage: `edamame stop`
+Usage: `edamame stop` <br />
 Outputs:
 
 ```
@@ -94,7 +94,7 @@ Outputs:
 
 ### edamame get --all
 
-Usage: `edamame get --all`
+Usage: `edamame get --all` <br />
 Outputs:
 
 ```
@@ -114,8 +114,8 @@ Outputs:
 
 ### edamame get --name
 
-Usage: `edamame get --name "<test name>"`
-Alternative Usage: `edamame get -n "<test name>"`
+Usage: `edamame get --name "<test name>"` <br />
+Alternative Usage: `edamame get -n "<test name>"` <br />
 Outputs:
 
 ```
@@ -164,7 +164,7 @@ export default function () {
 
 ### edamame delete
 
-Usage: `edamame delete "<test name>"`
+Usage: `edamame delete "<test name>"` <br />
 Outputs:
 
 ```
@@ -178,8 +178,8 @@ Outputs:
 
 ### edamame update
 
-Usage: `edamame update --current "<current test name>" --new "<new proposed name>"`
-Alternative usage: `edamame update -c "<current test name>" -n "<new proposed name>"`
+Usage: `edamame update --current "<current test name>" --new "<new proposed name>"` <br />
+Alternative usage: `edamame update -c "<current test name>" -n "<new proposed name>"` <br />
 Outputs:
 
 ```
@@ -193,7 +193,7 @@ Outputs:
 
 ### edamame grafana --start
 
-Usage: `edamame grafana --start`
+Usage: `edamame grafana --start` <br />
 Outputs:
 
 ```
@@ -206,7 +206,7 @@ Outputs:
 
 ### edamame grafana --stop
 
-Usage: `edamame grafana --stop`
+Usage: `edamame grafana --stop` <br />
 Outputs:
 
 ```
@@ -218,7 +218,7 @@ Outputs:
 
 ### edamame dashboard --start
 
-Usage: `edamame dashboard --start`
+Usage: `edamame dashboard --start` <br />
 Outputs:
 
 ```
@@ -242,7 +242,7 @@ Outputs:
 
 ### edamame dashboard --stop
 
-Usage: `edamame dashboard --stop`
+Usage: `edamame dashboard --stop` <br />
 Outputs:
 
 ```
@@ -255,14 +255,15 @@ Outputs:
 
 ### edamame archive
 
-Usage: `edamame archive --all`
-Alternative Usage: `edamame archive --name testName`
+Usage: `edamame archive --all` <br />
+Alternative Usage: `edamame archive --name testName --storage desiredStorageClass` <br />
 Outputs:
 
 `$ edamame archive --name "100K VUs"`
 
 ```
 [04:08:56:294] ℹ Starting archive process...
+[04:08:56:297] ℹ No S3 storage class has been specified, so the default STANDARD S3 storage class will be used.
 [04:08:56:544] ℹ Creating load test AWS S3 Bucket located in: aws-region=us-west-2
  if it doesn't exist yet...
 [04:09:01:715] ℹ AWS S3 Bucket is ready for uploads.
@@ -270,7 +271,7 @@ Outputs:
 [04:09:03:366] ✔ Archive process complete.
 ```
 
-`$ edamame archive --all`
+`$ edamame archive --all --storage INTELLIGENT_TIERING`
 
 ```
 [01:57:28:276] ℹ Starting archive process...
@@ -282,14 +283,30 @@ Outputs:
 [01:57:34:728] ✔ Archive process complete.
 ```
 
-- Uploads 1 or more load tests to an AWS S3 Bucket as S3 objects with the standard infrequent access storage class.
-- Purpose: allow user to back up their load test data to AWS S3 in case they need or want to teardown their Edamame EKS cluster, but want to persist their load test data. A user should execute this command prior to executing `edamame teardown`.
-- There isn't currently support for changing the S3 object's storage class to another class via the Edamame CLI. If a user wants to change the storage class to a Glacier category for even cheaper cold storage they can do so, but will need to use the AWS CLI or management console.
+- Uploads 1 or more load tests to an AWS S3 Bucket as S3 objects with either the default STANDARD S3 storage class or the user's specified storage class. The bucket will be created in the same region that the user's AWS CLI is configured with.
+- Purpose: allow user to back up their load test data to AWS S3 in case they need or want to teardown their Edamame EKS cluster, but want to persist their load test data beyond the life of the cluster. A user should execute this command prior to executing `edamame teardown`.
+- A user can select any of the following valid storage class options:
+
+  - STANDARD (Standard)
+  - REDUCED_REDUNDANCY (Reduced Redundancy)
+  - STANDARD_IA (Standard Infrequent Access)
+  - ONEZONE_IA (One Zone Infrequent Access)
+  - INTELLIGENT_TIERING (Standard Intelligent-Tiering)
+  - GLACIER (Glacier Flexible Retrieval)
+  - DEEP_ARCHIVE (Glacier Deep Archive)
+  - GLACIER_IR (Glacier Instant Retrieval)
+
+- The available storage options have different associated fees & availability SLAs. Some of the classes also have retrieval charges and minimum storage duration charges. Be sure to read more about the options at the following links to make sure you specify the right class for your storage needs.
+
+  - https://aws.amazon.com/s3/storage-classes/
+  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
+
+- There isn't currently support for changing the S3 object's storage class to another class via the Edamame CLI outside of restoring the object (see `edamame restore` for more details). If a user wants to change the storage class they can do so, but will need to use the AWS CLI or management console.
 
 ### edamame delete-from-archive
 
-Usage: `edamame delete-from-archive --all`
-Alternative Usage: `edamame delete-from-archive --name "100K VUs"`
+Usage: `edamame delete-from-archive --all` <br />
+Alternative Usage: `edamame delete-from-archive --name "100K VUs"` <br />
 Outputs:
 
 ```
@@ -302,8 +319,7 @@ Outputs:
 
 ### edamame archive-contents
 
-Usage: `edamame archive-contents`
-
+Usage: `edamame archive-contents` <br />
 Outputs:
 
 ```
@@ -318,8 +334,8 @@ Outputs:
 
 ### edamame import-from-archive
 
-Usage: `edamame import-from-archive --all`
-Alternative Usage: `edamame import-from-archive --name testName`
+Usage: `edamame import-from-archive --all` <br />
+Alternative Usage: `edamame import-from-archive --name testName` <br />
 Outputs:
 
 `$ edamame import-from-archive --name "100K VUs"`
@@ -334,9 +350,24 @@ Outputs:
 - If the --all flag is provided then all load test AWS S3 objects will be imported.
 - If the import command is executed after a user executes load tests in their current cluster and there is an overlap in the import data and the data in the Postgres database in the cluster, then the import process will be aborted. There currently isn't support for importing data with a test that has the same name as a test that already exists in the Postgres database. As a result, it's recommended that a user executes `edamame import-from-archive` immediately after `edamame init` to avoid name collisions.
 
+### edamame restore
+
+Usage: `edamame restore --name testName --days 10` <br />
+Outputs:
+
+```
+[02:25:18:043] ℹ Starting restoration of AWS S3 object...
+[02:25:19:060] ✔ AWS S3 restoration process is in progress. Once it's complete you can import data associated with testName into your current Edamame EKS cluster or move the S3 object elsewhere.
+```
+
+- Restores an S3 object with the storage class GLACIER, DEEP_ARCHIVE, DEEP_ARCHIVE_ACCESS INTELLIGENT_TIERING, or ARCHIVE_ACCESS INTELLIGENT_TIERING to allow for importing the data associated with the specified load test that's stored in the S3 Object into the current Edamame EKS cluster or moving it to an alternative location.
+- The number of days flag is required if the S3 object has the GLACIER or DEEP_ARCHIVE storage class. The argument passed to the number of days flag should be a number between 1 and 30 days.
+- If the S3 object has the class GLACIER or DEEP_ARCHIVE then the object will be temporarily restored to the STANDARD class for the specified number of days. If the S3 object has the INTELLIGENT_TIERING class with an archive status of either DEEP_ARCHIVE_ACCESS or ARCHIVE_ACCESS, the object will be restored to the Frequent Access tier.
+- Please note that restoration is not immediate and how long it takes is dependent on AWS. As a result, one cannot execute `edamame import-from-archive` immediately after executing `edamame restore`.
+
 ### edamame teardown
 
-Usage: `edamame teardown`
+Usage: `edamame teardown` <br />
 Outputs:
 
 ```

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "edamame": "src/index.js"
   },
   "scripts": {
-    "test:cli": "jest --testPathPattern=src/__tests__/cli/utilities",
-    "test:manifest": "jest --testPathPattern=src/__tests__/cli/manifests"
+    "test:utilities": "jest --testPathPattern=src/__tests__/cli/utilities",
+    "test:manifest": "jest --testPathPattern=src/__tests__/cli/manifests",
+    "test:commands": "jest --testPathPattern=src/__tests__/cli/commands"
   },
   "keywords": [],
   "license": "ISC",

--- a/src/__tests__/cli/utilities/archiver.js
+++ b/src/__tests__/cli/utilities/archiver.js
@@ -1,0 +1,77 @@
+import aws from "../../../utilities/aws.js";
+import archiver from "../../../utilities/archiver.js";
+import dbApi from "../../../utilities/dbApi.js";
+import archiveMessage from "../../../utilities/archiveMessage.js";
+
+jest.mock("../../../utilities/dbApi.js", () => ({
+  archive: jest.fn(() => {}),
+  getTest: jest.fn(() => {
+    return "";
+  }),
+  getAllTests: jest.fn(() => {
+    return [];
+  }),
+}));
+
+jest.mock("../../../utilities/aws.js", () => ({
+  s3ObjectExists: jest.fn(() => {
+    return `{
+      "AcceptRanges": "bytes",
+      "Restore": "ongoing-request=\"true\"",
+      "ContentType": "application/x-tar",
+      "Metadata": {},
+      "StorageClass": "GLACIER"
+    }`;
+  }),
+}));
+
+const fakeSpinner = {
+  info(message) {
+    return message;
+  },
+};
+
+test("Expect archive function not to be called when uploading to AWS if test has already been archived", async () => {
+  await archiver.uploadToAWS("test1", fakeSpinner, "STANDARD");
+  expect(dbApi.archive).not.toBeCalled();
+});
+
+test("Expect error to be thrown if user passes in test name to archive that doesn't exist", async () => {
+  expect.assertions(1);
+  try {
+    await archiver.allTestsToArchive("fake test name");
+  } catch (error) {
+    expect(error.message).toMatch("Nonexistent test to archive");
+  }
+});
+
+test("Expect error to be thrown if user tries to archive all tests when they haven't executed any load tests", async () => {
+  expect.assertions(1);
+  try {
+    await archiver.allTestsToArchive();
+  } catch (error) {
+    expect(error.message).toMatch("There are no tests to archive");
+  }
+});
+
+test("Expect STANDARD storage to be returned if no storage class is provided and storage is thus initially set as undefined", () => {
+  const storage = archiver.validateStorageClass(undefined);
+  expect(storage).toEqual("STANDARD");
+});
+
+test("Expect passed in storage class to be returned if it's one of the valid classes", () => {
+  const validClass = "REDUCED_REDUNDANCY";
+  const storage = archiver.validateStorageClass(validClass);
+  expect(storage).toEqual(validClass);
+});
+
+test("Expect error to be thrown if invalid storage class is passed in", () => {
+  expect.assertions(1);
+  try {
+    archiver.validateStorageClass("invalid class");
+  } catch (error) {
+    expect(error.message).toEqual(
+      "Invalid AWS S3 storage class specified: invalid class"
+    );
+  }
+});

--- a/src/__tests__/cli/utilities/aws.js
+++ b/src/__tests__/cli/utilities/aws.js
@@ -43,6 +43,8 @@ jest.mock("util", () => ({
   }),
 }));
 
+jest.mock("../../../utilities/dbApi.js", () => ({}));
+
 describe("Check logic that processes aws cli commands' inputs and outputs", () => {
   test("Account id number should be extracted from aws sts get-caller-identity stdout", async () => {
     await expect(aws.getAccountId()).resolves.toMatch(fakeAccountNum);
@@ -64,10 +66,6 @@ describe("Check logic that processes aws cli commands' inputs and outputs", () =
     await expect(aws.archiveBucketExists()).resolves.toEqual(true);
   });
 
-  test("True is returned when checking for existing AWS S3 Object", async () => {
-    await expect(aws.s3ObjectExists()).resolves.toEqual(true);
-  });
-
   test("Error is thrown when user doesn't list their desired availability zones in expected list format", () => {
     expect.assertions(1);
     try {
@@ -78,8 +76,9 @@ describe("Check logic that processes aws cli commands' inputs and outputs", () =
   });
 
   test("Error is thrown when user doesn't specify availability zone names that align with AWS naming conventions", () => {
+    expect.assertions(1);
     try {
-      aws.checkForInvalidZoneList("uswest2auswest2b");
+      aws.checkForInvalidZoneList("uswest2a");
     } catch (error) {
       expect(error.message).toEqual(invalidUserAVZoneInput);
     }

--- a/src/commands/archive.js
+++ b/src/commands/archive.js
@@ -1,58 +1,34 @@
 import aws from "../utilities/aws.js";
-import dbApi from "../utilities/dbApi.js";
 import archiveMessage from "../utilities/archiveMessage.js";
+import archiver from "../utilities/archiver.js";
 import Spinner from "../utilities/spinner.js";
-
-const uploadToAWS = async (testName, spinner) => {
-  try {
-    const s3Name = aws.s3ObjectNameForTest(testName);
-    const exists = await aws.s3ObjectExists(s3Name);
-
-    if (exists) {
-      spinner.info(archiveMessage.alreadyExists(testName));
-    } else {
-      await dbApi.archive("archive", testName);
-      spinner.info(archiveMessage.uploadSuccess(testName));
-    }
-  } catch (error) {
-    spinner.info(archiveMessage.sizeIssue(testName));
-  }
-};
-
-const allTestsToArchive = async (testName) => {
-  let testsToArchive;
-  if (testName) {
-    const test = await dbApi.getTest(testName);
-    if (!test) {
-      throw new Error(archiveMessage.nonexistentTest(testName));
-    }
-    testsToArchive = [test];
-  } else {
-    testsToArchive = await dbApi.getAllTests();
-    if (testsToArchive.length === 0) {
-      throw new Error(archiveMessage.noTests);
-    }
-  }
-  return testsToArchive;
-};
 
 const archive = async (options) => {
   const spinner = new Spinner(archiveMessage.start);
   const testName = options.name;
+  const storage = options.storage;
 
   try {
-    const testsToArchive = await allTestsToArchive(testName);
+    const storageClass = archiver.validateStorageClass(storage);
+    if (storage === undefined) {
+      spinner.info(archiveMessage.defaultStorageClass);
+    }
+    const testsToArchive = await archiver.allTestsToArchive(testName);
     spinner.info(archiveMessage.createBucketInRegion());
     await aws.setUpArchiveBucket();
     spinner.info(archiveMessage.bucketReady);
 
     for (let i = 0; i < testsToArchive.length; i++) {
-      await uploadToAWS(testsToArchive[i].name, spinner);
+      await archiver.uploadToAWS(testsToArchive[i].name, spinner, storageClass);
     }
 
     spinner.succeed(archiveMessage.exportComplete);
   } catch (err) {
-    spinner.fail(archiveMessage.error(err, "upload"));
+    if (err.message.match("Invalid AWS S3 storage class")) {
+      spinner.fail(`${err.message}\n ${archiveMessage.validStorageClasses()}`);
+    } else {
+      spinner.fail(archiveMessage.error(err, "upload"));
+    }
   }
 };
 

--- a/src/commands/deleteFromArchive.js
+++ b/src/commands/deleteFromArchive.js
@@ -8,12 +8,10 @@ const deleteFromArchive = async (options) => {
 
   try {
     if (testName) {
-      const s3Object = aws.s3ObjectNameForTest(testName);
-
-      const exists = await aws.s3ObjectExists(s3Object);
+      const exists = await aws.s3ObjectExists(testName);
       if (!exists) throw Error(archiveMessage.noObject(testName));
 
-      await aws.deleteObjectFromS3Bucket(s3Object);
+      await aws.deleteObjectFromS3Bucket(testName);
       spinner.succeed(archiveMessage.singleDeletionSuccess(testName));
     } else {
       await aws.deleteS3Bucket();

--- a/src/commands/getTests.js
+++ b/src/commands/getTests.js
@@ -10,8 +10,8 @@ const getTests = async () => {
     let tests = await dbApi.getAllTests();
     if (tests.length > 0) {
       spinner.succeed(
-        `Successfully retrieved historical test data.` +
-        `Test names are listed under (index).`
+        `Successfully retrieved historical test data. ` +
+          `Test names are listed under (index).`
       );
       dbApi.printTestDataTable(tests);
     } else {

--- a/src/commands/importFromArchive.js
+++ b/src/commands/importFromArchive.js
@@ -1,69 +1,26 @@
 import aws from "../utilities/aws.js";
-import dbApi from "../utilities/dbApi.js";
+import archiver from "../utilities/archiver.js";
 import Spinner from "../utilities/spinner.js";
 import archiveMessage from "../utilities/archiveMessage.js";
-
-const singleImport = async (testName, spinner) => {
-  try {
-    const response = await dbApi.archive("import", testName);
-    if (response.success) {
-      spinner.info(response.success);
-    }
-  } catch (err) {
-    const duplicate =
-      err.response && err.response.data && err.response.data.error;
-
-    const message = duplicate
-      ? archiveMessage.duplicateImport(testName)
-      : archiveMessage.singleImportFail(testName);
-
-    spinner.info(message);
-  }
-};
-
-const s3ObjectsToImport = async (testName) => {
-  let imports;
-  if (testName !== undefined) {
-    const bucketExists = await aws.archiveBucketExists();
-    if (!bucketExists) throw Error("NoSuchBucket");
-
-    const testExists = aws.s3ObjectExists(aws.s3ObjectNameForTest(testName));
-    if (!testExists) throw Error(archiveMessage.noObject(testName));
-
-    imports = [testName];
-  } else {
-    let s3Objects = await aws.listObjectsInS3Bucket();
-    imports = s3Objects.map((obj) => obj.split(".")[0]);
-  }
-  return imports;
-};
 
 const importFromArchive = async (options) => {
   const spinner = new Spinner(archiveMessage.startImport);
   const testName = options.name;
 
   try {
-    const s3Objects = await s3ObjectsToImport(testName);
+    const bucketExists = await aws.archiveBucketExists();
+    if (!bucketExists) throw Error(archiveMessage.noBucket);
+    const s3Objects = await archiver.s3ObjectsToImport(testName, spinner);
     for (let i = 0; i < s3Objects.length; i++) {
-      await singleImport(s3Objects[i], spinner);
+      await archiver.singleImport(s3Objects[i], spinner);
     }
     if (s3Objects.length > 0) {
       spinner.succeed(archiveMessage.importComplete);
     } else {
-      spinner.succeed(`No imports; ${archiveMessage.emptyBucket}`);
+      spinner.succeed(`No S3 Objects imported.`);
     }
   } catch (err) {
-    processImportError(err, spinner);
-  }
-};
-
-const processImportError = (error, spinner) => {
-  if (error.message.match("NoSuchBucket")) {
-    spinner.fail(archiveMessage.noBucket);
-  } else if (error.message.match("No s3 object")) {
-    spinner.fail(error.message);
-  } else {
-    spinner.fail(archiveMessage.error(error, "import"));
+    archiver.processImportError(err, spinner);
   }
 };
 

--- a/src/commands/restore.js
+++ b/src/commands/restore.js
@@ -1,0 +1,41 @@
+import aws from "../utilities/aws.js";
+import archiver from "../utilities/archiver.js";
+import Spinner from "../utilities/spinner.js";
+import archiveMessage from "../utilities/archiveMessage.js";
+import { RESTORE_BEFORE_IMPORT_S3_REGEX } from "../constants/constants.js";
+
+const restore = async (options) => {
+  const spinner = new Spinner(archiveMessage.startRestore);
+  const { name, days } = options;
+  const numDays = Number(days);
+
+  try {
+    const stdout = await aws.s3ObjectExists(name);
+    if (!stdout) {
+      throw Error(archiveMessage.noObject(name));
+    }
+
+    if (stdout.match(RESTORE_BEFORE_IMPORT_S3_REGEX)) {
+      const type = stdout.match("INTELLIGENT_TIERING")
+        ? "intelligent_tiering"
+        : "glacier";
+      if (type === "glacier") {
+        if (isNaN(numDays) || numDays < 0 || numDays > 30 || days.match(".")) {
+          throw Error(archiveMessage.invalidRestoreDays(days));
+        }
+      }
+      await aws.restoreS3Object(name, days, type);
+      spinner.succeed(archiveMessage.restorationInProgress(name));
+    } else {
+      spinner.succeed(archiveMessage.noRestorationNeeded(name));
+    }
+  } catch (error) {
+    if (error.message.match("Bad Request")) {
+      spinner.fail(archiveMessage.noBucket);
+    } else {
+      spinner.fail(error.message);
+    }
+  }
+};
+
+export { restore };

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -47,6 +47,18 @@ const EBS_CSI_DRIVER_REGEX =
   "ebs-csi-controller-sa.*AmazonEKS_EBS_CSI_DriverRole";
 const AWS_LBC_CRD = `"github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master"`;
 const AWS_LBC_POLICY_REGEX = `arn:aws:iam::.*EdamameAWSLoadBalancerControllerIAMPolicy`;
+const DEFAULT_AWS_S3_STORAGE_CLASS = "STANDARD";
+const VALID_STORAGE_CLASSES = {
+  STANDARD: "Standard",
+  REDUCED_REDUNDANCY: "Reduced Redundancy",
+  STANDARD_IA: "Standard Infrequent Access",
+  ONEZONE_IA: "One Zone Infrequent Access",
+  INTELLIGENT_TIERING: "Standard Intelligent-Tiering",
+  GLACIER: "Glacier Flexible Retrieval",
+  DEEP_ARCHIVE: "Glacier Deep Archive",
+  GLACIER_IR: "Glacier Instant Retrieval",
+};
+const RESTORE_BEFORE_IMPORT_S3_REGEX = `("ArchiveStatus": "(DEEP_ARCHIVE_ACCESS|ARCHIVE_ACCESS)"|"StorageClass": "(GLACIER|DEEP_ARCHIVE)")`;
 
 export {
   NUM_VUS_PER_POD,
@@ -94,7 +106,10 @@ export {
   AWS_LBC_CHART_VERSION,
   MIN_NUM_DASHES_FOR_GTEQ_2_AWS_AVZONES,
   SPECIALIZED_NODES_UNAVAILABLE_TIMEOUT,
+  RESTORE_BEFORE_IMPORT_S3_REGEX,
+  DEFAULT_AWS_S3_STORAGE_CLASS,
   DASHBOARD_PORT,
   LOAD_GEN_NODE_TYPE,
-  LOAD_AGG_NODE_TYPE
+  LOAD_AGG_NODE_TYPE,
+  VALID_STORAGE_CLASSES,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import { archive } from "./commands/archive.js";
 import { deleteFromArchive } from "./commands/deleteFromArchive.js";
 import { importFromArchive } from "./commands/importFromArchive.js";
 import { showArchiveContents } from "./commands/archiveContents.js";
+import { restore } from "./commands/restore.js";
 import { ARCHIVE } from "./constants/constants.js";
 
 const program = new Command();
@@ -114,10 +115,15 @@ program
     `Upload all load tests as S3 Objects to the ${ARCHIVE} AWS S3 Bucket`
   )
   .option("-n, --name <name>", "Name of specific test to archive")
+  .option(
+    "-s, --storage <storage>",
+    "Desired storage class for the AWS S3 Object"
+  )
   .description(
-    `Move load test data from EBS volume to AWS S3 Glacier to allow for persistent test ` +
+    `Move load test data from EBS volume to AWS S3 Bucket to allow for persistent test ` +
       ` data storage beyond the life of the Edamame EKS cluster. If test name flag isn't ` +
-      ` provided, then all existing test data will be archived. `
+      ` provided, then all existing test data will be archived. If the storage flag isn't ` +
+      ` provided, then the default STANDARD storage class will be used.`
   )
   .action(archive);
 
@@ -144,6 +150,15 @@ program
     `Imports historical load test data stored in ${ARCHIVE} AWS S3 Bucket to the Postgres database`
   )
   .action(importFromArchive);
+
+program
+  .command("restore")
+  .requiredOption("-n, --name <name>", "Name of specific test to restore")
+  .option("-d, --days <days>", "Number of days to restore the AWS S3 Object")
+  .description(
+    `Restores AWS S3 object associated with a given load test to the STANDARD storage class for the specified # of days`
+  )
+  .action(restore);
 
 program
   .command("archive-contents")

--- a/src/utilities/archiveMessage.js
+++ b/src/utilities/archiveMessage.js
@@ -16,6 +16,8 @@ const archiveMessage = {
 
   emptyBucket: "Your AWS S3 Edamame load test bucket is empty.",
 
+  startRestore: "Starting restoration of AWS S3 object...",
+
   deletedBucket: "Deleted Edamame load test AWS S3 bucket",
 
   startDeletion: "Starting archival deletion process...",
@@ -23,6 +25,39 @@ const archiveMessage = {
   importComplete: "Completed importing data from AWS S3.",
 
   exportComplete: "Archive process complete.",
+
+  defaultStorageClass:
+    "No S3 storage class has been specified, so the default STANDARD S3 storage class will be used.",
+
+  restoreInProgress:
+    "S3 Object is in the process of being restored and can't be imported yet.",
+
+  restorationInProgress(name) {
+    return (
+      `AWS S3 restoration process is in progress. Once its complete you ` +
+      ` can import data associated with ${name} into your current Edamame ` +
+      ` EKS cluster or move the S3 object elsewhere.`
+    );
+  },
+
+  restoreBeforeImport(testName) {
+    return (
+      `Can't import ${testName}; Its S3 storage class requires it` +
+      ` to be restored before imported.\n See the edamame restore` +
+      ` command in the docs for more details.`
+    );
+  },
+
+  noRestorationNeeded(testName) {
+    return (
+      `AWS S3 Object associated with the test ${testName} ` +
+      `doesn't have a storage class that requires restoration.`
+    );
+  },
+
+  invalidRestoreDays(days) {
+    return `Invalid days flag argument: ${days}. Number of days should be 1-30.`;
+  },
 
   nonexistentTest(testName) {
     return `Nonexistent test to archive: ${testName}.`;
@@ -74,7 +109,7 @@ const archiveMessage = {
   },
 
   noObject(testName) {
-    return `No s3 object associated with the test named ${testName}.`;
+    return `There's no AWS S3 object associated with the test named ${testName}.`;
   },
 
   singleDeletionSuccess(name) {

--- a/src/utilities/archiver.js
+++ b/src/utilities/archiver.js
@@ -1,0 +1,109 @@
+import aws from "../utilities/aws.js";
+import dbApi from "../utilities/dbApi.js";
+import archiveMessage from "../utilities/archiveMessage.js";
+import {
+  DEFAULT_AWS_S3_STORAGE_CLASS,
+  RESTORE_BEFORE_IMPORT_S3_REGEX,
+  VALID_STORAGE_CLASSES,
+} from "../constants/constants.js";
+
+const archiver = {
+  async uploadToAWS(testName, spinner, storageClass) {
+    try {
+      const exists = await aws.s3ObjectExists(testName);
+
+      if (exists) {
+        spinner.info(archiveMessage.alreadyExists(testName));
+      } else {
+        await dbApi.archive("archive", testName, storageClass);
+        spinner.info(archiveMessage.uploadSuccess(testName));
+      }
+    } catch (error) {
+      spinner.info(archiveMessage.sizeIssue(testName));
+    }
+  },
+
+  validateStorageClass(storageClass) {
+    if (storageClass === undefined) {
+      return DEFAULT_AWS_S3_STORAGE_CLASS;
+    }
+
+    if (VALID_STORAGE_CLASSES.hasOwnProperty(storageClass)) {
+      return storageClass;
+    } else {
+      throw Error(`Invalid AWS S3 storage class specified: ${storageClass}`);
+    }
+  },
+
+  async allTestsToArchive(testName) {
+    let testsToArchive;
+    if (testName) {
+      const test = await dbApi.getTest(testName);
+      if (!test) {
+        throw new Error(archiveMessage.nonexistentTest(testName));
+      }
+      testsToArchive = [test];
+    } else {
+      testsToArchive = await dbApi.getAllTests();
+      if (testsToArchive.length === 0) {
+        throw new Error(archiveMessage.noTests);
+      }
+    }
+    return testsToArchive;
+  },
+
+  async validateObjectToImport(testName, spinner, list) {
+    const stdout = await aws.s3ObjectExists(testName);
+    if (!stdout) {
+      spinner.info(archiveMessage.noObject(testName));
+    } else if (stdout.match("ongoing-request")) {
+      spinner.info(archiveMessage.restoreInProgress);
+    } else if (stdout.match(RESTORE_BEFORE_IMPORT_S3_REGEX)) {
+      spinner.info(archiveMessage.restoreBeforeImport(testName));
+    } else {
+      list.push(testName);
+    }
+  },
+
+  async s3ObjectsToImport(testName, spinner) {
+    let imports = [];
+    if (testName !== undefined) {
+      await this.validateObjectToImport(testName, spinner, imports);
+    } else {
+      let s3Objects = await aws.listObjectsInS3Bucket();
+      for (let i = 0; i < s3Objects.length; i++) {
+        const testName = s3Objects[i].split(".")[0];
+        await this.validateObjectToImport(testName, spinner, imports);
+      }
+    }
+    return imports;
+  },
+
+  async singleImport(testName, spinner) {
+    try {
+      const response = await dbApi.archive("import", testName);
+      if (response.success) {
+        spinner.info(response.success);
+      }
+    } catch (err) {
+      const duplicate =
+        err.response && err.response.data && err.response.data.error;
+
+      const message = duplicate
+        ? archiveMessage.duplicateImport(testName)
+        : archiveMessage.singleImportFail(testName);
+
+      spinner.info(message);
+    }
+  },
+
+  processImportError(error, spinner) {
+    if (error.message.match("no AWS S3")) {
+      spinner.fail(error.message);
+    } else {
+      spinner.fail(archiveMessage.error(error, "import"));
+    }
+  },
+};
+
+export default archiver;

--- a/src/utilities/dbApi.js
+++ b/src/utilities/dbApi.js
@@ -10,7 +10,6 @@ import kubectl from "./kubectl.js";
 import eksctl from "./eksctl.js";
 import files from "./files.js";
 import axios from "axios";
-import aws from "./aws.js";
 
 const dbApi = {
   async nameExists(name) {
@@ -197,8 +196,9 @@ const dbApi = {
     }
   },
 
-  async archive(archivePath, testName) {
-    const url = `${this.url()}/${archivePath}/${testName}`;
+  async archive(archivePath, testName, storageClass) {
+    let url = `${this.url()}/${archivePath}/${testName}`;
+    if (archivePath === "archive") url += `?storage=${storageClass}`;
 
     try {
       let response = await axios.post(url, {});
@@ -206,6 +206,7 @@ const dbApi = {
     } catch {
       await this.restoreIp();
       const newUrl = `${this.url()}/${archivePath}/${testName}`;
+      if (archivePath === "archive") url += `?storage=${storageClass}`;
       let res = await axios.post(newUrl, {});
       return res.data;
     }


### PR DESCRIPTION
update:

- archive command to add storage flag to allow user to specify their desired S3 object storage class (default class selected is STANDARD if this flag isn't provided)
- add `edamame restore` command that allows user to restore S3 objects that have certain glacier related S3 storage classes (these objects can't be imported immediately and must be restored before they're imported via the `edamame import-from-archive` command)
- add tests for updates and edit readme for command updates

