### PR TITLE
add archive and unarchive to react ui

### DIFF
--- a/dashboard/backend-server/package.json
+++ b/dashboard/backend-server/package.json
@@ -8,7 +8,24 @@
     "dev": "node index.js",
     "start": "node index.js"
   },
-  "author": "Albert Dorfman",
+  "contributors": [
+    {
+      "name": "Albert Dorfman",
+      "github": "<https://github.com/elguaposalsero>"
+    },
+    {
+      "name": "Ginni Pinckert",
+      "github": "<https://github.com/gcpinckert>"
+    },
+    {
+      "name": "Luke Oguro",
+      "github": "<https://github.com//lukeoguro>"
+    },
+    {
+      "name": "Rachel West",
+      "github": "<https://github.com/westrachel>"
+    }
+  ],
   "license": "ISC",
   "dependencies": {
     "axios": "^1.3.4",

--- a/dashboard/backend-server/routes/script.js
+++ b/dashboard/backend-server/routes/script.js
@@ -10,6 +10,7 @@ export let options = {
 
 export default function () {
   const result = http.get("https://test-api.k6.io/public/crocodiles/");
+
   check(result, {
     "http response status code is 200": result.status === 200,
   });

--- a/dashboard/backend-server/routes/testRoutes.js
+++ b/dashboard/backend-server/routes/testRoutes.js
@@ -10,7 +10,12 @@ import { deleteTest } from "../../../src/commands/deleteTest.js";
 import { stopTest } from "../../../src/commands/stopTest.js";
 import { destroyEKSCluster } from "../../../src/commands/destroy.js";
 import dbApi from "../../../src/utilities/dbApi.js";
-import { NUM_VUS_PER_POD } from "../../../src/constants/constants.js";
+import aws from "../../../src/utilities/aws.js";
+import testService from "../services/testService.js";
+import {
+  NUM_VUS_PER_POD,
+  DEFAULT_AWS_S3_STORAGE_CLASS,
+} from "../../../src/constants/constants.js";
 const router = express.Router();
 router.use(express.json());
 
@@ -18,12 +23,45 @@ dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+router.get("/archive/:name", async (req, res) => {
+  const name = req.params.name;
+  try {
+    const exists = await testService.testArchiveExists(name);
+    res.status(200).json({ archiveExists: exists });
+  } catch {
+    res.status(500).send("Issue communicating with AWS. Try again later");
+  }
+});
+
 router.get("/", async (req, res) => {
   try {
     const data = await dbApi.getAllTests();
     res.json(data);
   } catch (error) {
     console.log(`Error getting list of tests dbAPI: ${error}`);
+  }
+});
+
+router.post("/archive/:name", async (req, res) => {
+  const name = req.params.name;
+  let storage = req.query.storage;
+  if (storage === undefined) storage = DEFAULT_AWS_S3_STORAGE_CLASS;
+  await testService.setupS3Bucket();
+  const archiveExists = await testService.testArchiveExists(name);
+
+  if (archiveExists) {
+    res.status(400).send({
+      error: `S3 Archive object already exists for the test: ${name}`,
+    });
+  } else {
+    try {
+      const response = await dbApi.archive("archive", name, storage);
+      res.status(201).send(response.data);
+    } catch {
+      res.status(500).send({
+        error: `Couldn't communicate with AWS. Please try archiving again later.`,
+      });
+    }
   }
 });
 
@@ -50,9 +88,16 @@ router.post("/", async (req, res) => {
   });
 });
 
+router.delete("/archive/:name", async (req, res) => {
+  const name = req.params.name;
+  await aws.deleteObjectFromS3Bucket(name);
+  res.status(204).send();
+});
+
 router.delete("/:name", async (req, res) => {
   const name = req.params.name;
   deleteTest(name);
+  res.status(204).send();
 });
 
 router.post("/stop", (req, res) => {

--- a/dashboard/backend-server/services/testService.js
+++ b/dashboard/backend-server/services/testService.js
@@ -1,0 +1,29 @@
+import { ARCHIVE } from "../../../src/constants/constants.js";
+import { promisify } from "util";
+import child_process from "child_process";
+const exec = promisify(child_process.exec);
+
+const testService = {
+  async setupS3Bucket() {
+    try {
+      const { stdout } = await exec(`aws s3 ls s3://${ARCHIVE}`);
+    } catch {
+      await exec(`aws s3 mb s3://${ARCHIVE}`);
+    }
+  },
+
+  async testArchiveExists(testName) {
+    const command =
+      `aws s3api head-object --bucket ${ARCHIVE} ` +
+      `--key ${testName.replaceAll(" ", "")}.tar.gz`;
+
+    try {
+      const { stdout } = await exec(command);
+      return stdout !== "";
+    } catch {
+      return false;
+    }
+  },
+};
+
+export default testService;

--- a/dashboard/frontend/package-lock.json
+++ b/dashboard/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
         "react-scripts": "5.0.1",
+        "react-select": "^5.7.4",
         "uuid": "^9.0.0",
         "web-vitals": "^2.1.4"
       },
@@ -2790,6 +2791,128 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
+      "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+      "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2891,6 +3014,28 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+      "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -4884,8 +5029,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -4906,7 +5050,6 @@
       "version": "18.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.14.tgz",
       "integrity": "sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4918,6 +5061,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
       "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
       "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
+      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -4938,8 +5089,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -7351,8 +7501,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7639,6 +7788,15 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -8975,6 +9133,11 @@
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -9635,6 +9798,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -12979,6 +13155,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -15660,6 +15841,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/react-select": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.4.tgz",
+      "integrity": "sha512-NhuE56X+p9QDFh4BgeygHFIvJJszO1i1KSkg/JPcIJrbovyRtI+GuOEa4XzFCEpZRAEoEI8u/cAHK+jG/PgUzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
@@ -15692,6 +15893,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -17005,6 +17221,11 @@
         "postcss": "^8.2.15"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -17604,6 +17825,19 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -8,6 +8,7 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
     "react-scripts": "5.0.1",
+    "react-select": "^5.7.4",
     "uuid": "^9.0.0",
     "web-vitals": "^2.1.4"
   },

--- a/dashboard/frontend/src/__tests__/ArchiveComponents.jsx
+++ b/dashboard/frontend/src/__tests__/ArchiveComponents.jsx
@@ -1,0 +1,106 @@
+/**
+  *@jest-environment jsdom
+  */
+
+import "@testing-library/jest-dom";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import ArchiveModal from "../components/ArchiveModal";
+import testService from "../services/testService";
+
+const name = "test1";
+jest.mock("axios");
+
+afterEach(cleanup);
+
+describe('Archive Modal rendering when archiveExists is initial empty string b/c have not checked AWS S3 contents yet', () => {
+  beforeAll(() => {
+    render(<ArchiveModal archiveTestName={name} setIsArchiveModal={() => {}} />);
+  });
+
+  test("Expect archive modal display to show temporary message that archive content's is being checked for the test", () => {
+    const heading = screen.getByRole("heading").innerHTML;
+    expect(heading).toEqual(`Manage Your AWS S3 Archive`);
+    expect(screen.getByText(/Checking to see if test1 already exists in the archive.../)).toBeVisible();
+  });
+});
+
+describe('Archive Modal rendering when archiveExists is false b/c test does not exist in AWS S3', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(React, 'useState')
+      .mockImplementationOnce(() => React.useState(false));
+    
+    jest
+      .spyOn(React, "useEffect")
+      .mockImplementation(jest.fn());
+
+    jest
+      .spyOn(testService, "archiveExists")
+      .mockImplementation(jest.fn(() => Promise.resolve(false)));
+    
+    jest
+      .spyOn(testService, "archiveTest")
+      .mockImplementation(jest.fn(() => Promise.resolve("")));
+    render(<ArchiveModal archiveTestName={name} setIsArchiveModal={() => {}} />);
+  });
+
+  test("Expect archive modal display to show upload related heading and buttons", () => {
+    const heading = screen.getByRole("heading").innerHTML;
+    expect(heading).toEqual(`Archive ${name} in AWS S3`);
+    const awsButton = screen.getByRole("button", {"name": "Read about S3 storage options"});
+    expect(awsButton).toBeVisible();
+    const cancelButton = screen.getByRole("button", {"name": "Cancel"});
+    expect(cancelButton).toBeVisible();
+    const archiveButton = screen.getByRole("button", {"name": "Archive test"});
+    expect(archiveButton).toBeVisible();
+  });
+
+
+  test("Expect temporary highlight message and archive test button to be disabled after user clicks archive test", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(screen.getByRole("button", {"name": "Archive test"}));
+    });
+    const deleteButton = screen.getByRole("button", {"name": "Archive test"});
+    expect(deleteButton).toHaveAttribute("disabled");
+    expect(screen.getByText(/upload/i)).toBeInTheDocument();
+  });
+});
+
+describe('Archive Modal rendering when archiveExists is true b/c test exists in AWS S3', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(React, 'useState')
+      .mockImplementationOnce(() => React.useState(true));
+  
+    jest
+      .spyOn(React, "useEffect")
+      .mockImplementation(jest.fn());
+
+    jest
+      .spyOn(testService, "archiveExists")
+      .mockImplementation(jest.fn(() => Promise.resolve(true)));
+    render(<ArchiveModal archiveTestName={name} setIsArchiveModal={() => {}} />);
+  });
+
+  test("Expect archive modal display to show delete from archive heading and buttons", () => {
+    const heading = screen.getByRole("heading").innerHTML;
+    expect(heading).toEqual(`${name} Exists in AWS S3 Archive`);
+    const cancelButton = screen.getByRole("button", {"name": "Cancel"});
+    expect(cancelButton).toBeVisible();
+    const archiveButton = screen.getByRole("button", {"name": "Delete test from archive"});
+    expect(archiveButton).toBeVisible();
+  });
+
+  test("Expect temporary highlight message and delete button to be disabled after user clicks delete from archive", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(screen.getByRole("button", {"name": "Delete test from archive"}));
+    });
+    const deleteButton = screen.getByRole("button", {"name": "Delete test from archive"});
+    expect(deleteButton).toHaveAttribute("disabled");
+    expect(screen.getByText(/from AWS S3/)).toBeInTheDocument();
+  });
+});

--- a/dashboard/frontend/src/__tests__/Menu.jsx
+++ b/dashboard/frontend/src/__tests__/Menu.jsx
@@ -1,0 +1,50 @@
+/**
+  *@jest-environment jsdom
+  */
+
+import "@testing-library/jest-dom";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import testService from "../services/testService";
+import Menu from "../components/Menu";
+
+const tests = [{
+  "id": 1,
+  "name": "50k VUs",
+  "start_time": "2023-03-18T18:54:51.611Z",
+  "end_time": "2023-03-18T18:56:59.596Z",
+  "status": "completed",
+  "script": "...test script content..."
+}];
+
+const setState = jest.fn();
+
+jest
+  .spyOn(testService, "deleteTest")
+  .mockImplementation(jest.fn(() => Promise.resolve("")));
+
+beforeEach(() => {
+  render(<Menu 
+    test={tests[0]} 
+    setMenu={setState}
+    tests={tests}
+    setTests={setState}
+    setIsScriptModal={setState}
+    setCurrScript={setState}
+    setIsArchiveModal={setState}
+    setArchiveTestName={setState} />);
+});
+
+test("Expect html tags for viewing script, archiving test, and deleting a test to render", () => {
+  expect(screen.queryByText("See script")).toBeVisible();
+  expect(screen.queryByText("Archive")).toBeVisible();
+  expect(screen.queryByText("Delete")).toBeVisible();
+});
+
+test("Expect to call delete test action with current test name when delete is clicked", async () => {
+  const user = userEvent.setup();
+  await act(async () => {
+    await user.click(screen.queryByText("Delete"));
+  });
+  expect(testService.deleteTest).toBeCalledWith(tests[0].name);
+});

--- a/dashboard/frontend/src/__tests__/ScriptModal.jsx
+++ b/dashboard/frontend/src/__tests__/ScriptModal.jsx
@@ -7,8 +7,6 @@ import { render, screen } from "@testing-library/react";
 import ScriptModal from "../components/ScriptModal";
 jest.mock("axios");
 
-// <ScriptModal setIsScriptModal={setIsScriptModal} currScript={currScript}/>
-
 beforeEach(() => {
   const setStateMock = jest.fn();
   const currScript = "import http from ''k6/http'';\n" +

--- a/dashboard/frontend/src/components/ArchiveDelete.jsx
+++ b/dashboard/frontend/src/components/ArchiveDelete.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import testService from "../services/testService";
+
+function ArchiveDelete({ archiveTestName, setIsArchiveModal, archiveMessage, setArchiveMessage, clearModal }) {
+  async function handleUnarchivingTest(e) {
+    e.preventDefault();
+    setArchiveMessage(`Deleting ${archiveTestName} from AWS S3...`);
+    try {
+      await testService.deleteTestFromArchive(archiveTestName);
+      setArchiveMessage(`Successfully deleted ${archiveTestName} from AWS S3.`);
+      clearModal(4000);
+    } catch {
+      setArchiveMessage(`Issue communicating with AWS to delete ` +
+        `${archiveTestName} from AWS S3. Please try again later.`);
+      clearModal(6000);
+    }
+  }
+
+  return (
+    <div className="inset-0 ">
+      <div className={`bg-white max-w-xl h-${archiveMessage ? 2 : 1}/6 rounded p-5 absolute top-20 left-1/2 transform -translate-x-1/2 w-[70%]`}>
+        <h2 className="text-xl font-bold pb-5">{`${archiveTestName} Exists in AWS S3 Archive`}</h2> 
+        {archiveMessage && <p className="text-pink rounded-md px-3 py-2 pl-4 pr-4 pb-3 mb-4 bg-pink/10">{archiveMessage}</p>}
+        <p>
+          {`You have already uploaded ${archiveTestName} to your AWS S3 Bucket. If you no longer want it in your archive, you can delete it.`}
+        </p>
+        <div className="flex gap-2 justify-end mt-6">
+        <button
+          className="border border-slate-400 rounded px-3 py-2 flex gap-1 text-slate-500"
+          onClick={() => setIsArchiveModal(false)}
+        >
+          {archiveMessage !== "" ? "Close" : "Cancel" }
+        </button>  
+        <button
+          className={`bg-blue antialiased text-white rounded px-3 py-2 flex gap-1 ${
+            archiveMessage !== "" ? "opacity-50" : ""
+          }`}
+          onClick={handleUnarchivingTest}
+          disabled={archiveMessage !== ""}
+        >
+          Delete test from archive
+        </button>
+        </div>
+      </div>
+     </div>
+  );
+}
+
+export default ArchiveDelete;

--- a/dashboard/frontend/src/components/ArchiveModal.jsx
+++ b/dashboard/frontend/src/components/ArchiveModal.jsx
@@ -1,0 +1,70 @@
+import ArchiveUpload from "./ArchiveUpload";
+import ArchiveDelete from "./ArchiveDelete";
+import { useState, useEffect } from "react";
+import testService from "../services/testService";
+
+function ArchivePending({ archiveTestName }) {
+  return (
+    <div className="inset-0 ">
+      <div className="bg-white max-w-xl h-1/6 rounded p-5 absolute top-20 left-1/2 transform -translate-x-1/2 w-[70%]">
+        <h2 className="text-xl font-bold pb-5">{`Manage Your AWS S3 Archive`}</h2>       
+        {`Checking to see if ${archiveTestName} already exists in the archive...`}
+      </div>
+     </div>
+  );
+}
+
+function ArchiveModal({ archiveTestName, setIsArchiveModal }) {
+  const [archiveExists, setArchiveExists] = useState("");
+  const [archiveMessage, setArchiveMessage] = useState("");
+
+  function clearModal(time) {
+    setTimeout(() => {
+      setIsArchiveModal(false);
+      setArchiveMessage("");
+    }, time);
+  }
+
+  useEffect(() => {
+    async function checkArchiveForTest() {
+      try {
+        const data = await testService.archiveExists(archiveTestName);
+        setArchiveExists(data.archiveExists);
+      } catch {
+        setArchiveExists(false);
+      }
+    }
+    checkArchiveForTest();
+  }, [archiveTestName]);
+
+
+  return (
+    <>
+    {archiveExists === false &&
+      <ArchiveUpload 
+        archiveTestName={archiveTestName}
+        setIsArchiveModal={setIsArchiveModal}
+        archiveMessage={archiveMessage}
+        setArchiveMessage={setArchiveMessage}
+        clearModal={clearModal}
+      />
+    } 
+    {archiveExists &&
+      <ArchiveDelete
+        archiveTestName={archiveTestName}
+        setIsArchiveModal={setIsArchiveModal}
+        archiveMessage={archiveMessage}
+        setArchiveMessage={setArchiveMessage}
+        clearModal={clearModal}
+      />
+    }
+    {archiveExists === "" &&
+      <ArchivePending
+        archiveTestName={archiveTestName}
+      />
+    }
+    </>
+  );
+}
+
+export default ArchiveModal;

--- a/dashboard/frontend/src/components/ArchiveUpload.jsx
+++ b/dashboard/frontend/src/components/ArchiveUpload.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { useState } from "react";
+import testService from "../services/testService";
+import Select from 'react-select';
+import {
+  DEFAULT_AWS_S3_STORAGE_CLASS, 
+  VALID_STORAGE_CLASSES
+} from "../constants/constants.js";
+import { FiExternalLink } from "react-icons/fi";
+
+function ArchiveUpload({ archiveTestName, setIsArchiveModal, archiveMessage, setArchiveMessage, clearModal }) {
+  const [storageClass, setStorageClass] = useState(DEFAULT_AWS_S3_STORAGE_CLASS);
+
+  async function handleArchivingTest(e) {
+    e.preventDefault();
+    setArchiveMessage(`Uploading ${archiveTestName} to AWS S3...`);
+    try {
+      await testService.archiveTest(archiveTestName, storageClass);
+      setArchiveMessage(`Successfully uploaded ${archiveTestName} into AWS S3 with the storage class ${storageClass}.`);
+      clearModal(6000);
+    } catch (err) {
+      console.log(err);
+      setArchiveMessage(`Issue communicating with AWS to archive test: ${archiveTestName}. ` +
+       `Please try again later. If the issue persists, please reach out to an Edamame developer.` +
+       ` Your test may have a substantial amount of data and require a customized archive strategy.`);
+      clearModal(10000);
+    }
+  }
+
+  function handleChangeStorageClass(event) {
+    setStorageClass(event.value);
+  }
+
+  const storageOptions = Object.keys(VALID_STORAGE_CLASSES).map(storageClass => {
+    return { value: storageClass, label: VALID_STORAGE_CLASSES[storageClass]};
+  });
+
+  return (
+    <div className="inset-0 ">
+      <div className={`bg-white max-w-xl h-${archiveMessage ? 3 : 2}/6 rounded p-5 absolute top-20 left-1/2 transform -translate-x-1/2 w-[70%]`}>
+        <h2 className="text-xl font-bold pb-5">{`Archive ${archiveTestName} in AWS S3`}</h2>  
+        {archiveMessage && <p className="text-pink rounded-md px-3 py-2 pl-4 pr-4 pb-3 mb-4 bg-pink/10">{archiveMessage}</p>}
+        <p className="pb-10">
+          Archiving allows you to persist load test data beyond the life of your current cluster should you need or want to tear it down. 
+          The S3 storage classes available have varying charges and SLAs. Be sure to read the AWS docs linked below to select the storage
+          class that best fits your needs.
+        </p>
+        <p className="text-lg pb-2">Select an S3 Storage Class:</p>
+        <Select
+          options={storageOptions}
+          placeholder={VALID_STORAGE_CLASSES[storageClass]}
+          value={storageClass}
+          onChange={handleChangeStorageClass}
+        />
+        <div className="flex pt-3 gap-2 justify-end mt-6">
+          <a
+            href="https://aws.amazon.com/s3/storage-classes"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <button className="bg-pink antialiased text-white rounded px-2 py-2 flex gap-1">
+              Read about S3 storage options <FiExternalLink />
+            </button>
+          </a>
+          <button
+            className="border border-slate-400 rounded px-3 py-2 flex gap-1 text-slate-500"
+            onClick={() => setIsArchiveModal(false)}
+          >
+            {archiveMessage !== "" ? "Close" : "Cancel" }
+          </button>
+          <button
+            className={`bg-blue antialiased text-white rounded px-3 py-2 flex gap-1 ${
+              archiveMessage !== "" ? "opacity-50" : ""
+            }`}
+            onClick={handleArchivingTest}
+            disabled={archiveMessage !== ""}
+          >
+            Archive test
+          </button>
+        </div>
+      </div>
+     </div>
+  );
+}
+
+export default ArchiveUpload;

--- a/dashboard/frontend/src/components/LaunchTestModal.jsx
+++ b/dashboard/frontend/src/components/LaunchTestModal.jsx
@@ -1,9 +1,8 @@
 import { useState, useEffect } from "react";
 import { FiUploadCloud } from "react-icons/fi";
-import { v4 as uuidv4 } from "uuid";
 import testService from "../services/testService";
 
-function LaunchTestModal({ setIsModal, setTests, setCurrTest, currTest }) {
+function LaunchTestModal({ setIsModal, currTest }) {
   const [title, setTitle] = useState("");
   const [file, setFile] = useState(null);
   const [fileName, setFileName] = useState(null);
@@ -12,16 +11,7 @@ function LaunchTestModal({ setIsModal, setTests, setCurrTest, currTest }) {
 
   function handleSubmit(e) {
     e.preventDefault();
-    const newID = uuidv4();
     testService.startTest(title, file);
-
-    const newTest = {
-      id: newID,
-      name: title,
-      status: "Pending",
-      start_time: Date.now(),
-      script: JSON.stringify(file),
-    };
     setLoading(true);
   }
 
@@ -108,7 +98,7 @@ w-[70%]"
               <button
                 disabled
                 type="button"
-                class="text-white bg-blue  rounded px-3 py-2"
+                class="text-white bg-blue rounded px-3 py-2"
               >
                 <svg
                   aria-hidden="true"

--- a/dashboard/frontend/src/components/Menu.jsx
+++ b/dashboard/frontend/src/components/Menu.jsx
@@ -1,12 +1,25 @@
 import testService from "../services/testService";
 
-function Menu({ name, setMenu, setIsScriptModal, setCurrScript }) {
+function Menu({ test, setMenu, tests, setTests, setIsScriptModal, setCurrScript, setIsArchiveModal, setArchiveTestName }) {
   async function handleScript() {
     setIsScriptModal(true);
     setMenu(false);
-    const data = await testService.getTest(name);
-    await setCurrScript(data);
+    setCurrScript(test);
   }
+
+  async function handleArchive() {
+    setIsArchiveModal(true);
+    setMenu(false);
+    setArchiveTestName(test.name);
+  }
+
+  async function handleDelete() {
+    await testService.deleteTest(test.name);
+    const newTestList = tests.filter(aTest => aTest.name !== test.name);
+    setTests(newTestList);
+    setMenu(false);
+  }
+
   return (
     <>
       <div
@@ -24,11 +37,14 @@ function Menu({ name, setMenu, setIsScriptModal, setCurrScript }) {
           See script
         </p>
         <p
+          onClick={handleArchive}
+          className="hover:cursor-pointer hover:bg-slate-100 pl-4 py-2 pr-16"
+        >
+          Archive
+        </p> 
+        <p
           className="text-pink hover:cursor-pointer pl-4 pr-16 hover:bg-pink/10 py-2"
-          onClick={() => {
-            testService.deleteTest(name);
-            setMenu(false);
-          }}
+          onClick={handleDelete}
         >
           Delete
         </p>

--- a/dashboard/frontend/src/components/TestList.jsx
+++ b/dashboard/frontend/src/components/TestList.jsx
@@ -2,6 +2,7 @@ import { FiExternalLink, FiMoreVertical } from "react-icons/fi";
 import { useState, useEffect } from "react";
 import testService from "../services/testService";
 import ScriptModal from "./ScriptModal";
+import ArchiveModal from "./ArchiveModal";
 import LaunchTestModal from "./LaunchTestModal";
 import generateGrafanaUrl from "../utilities/generateGrafanaUrl";
 import format from "../utilities/formatter";
@@ -10,6 +11,8 @@ import Menu from "./Menu";
 function TestList({ currTest, setCurrTest }) {
   const [tests, setTests] = useState([]);
   const [isScriptModal, setIsScriptModal] = useState(false);
+  const [archiveTestName, setArchiveTestName] = useState("");
+  const [isArchiveModal, setIsArchiveModal] = useState(false);
   const [currScript, setCurrScript] = useState({});
   const [isModal, setIsModal] = useState(false);
   const [menu, setMenu] = useState(null);
@@ -55,15 +58,19 @@ function TestList({ currTest, setCurrTest }) {
         {isModal && (
           <LaunchTestModal
             setIsModal={setIsModal}
-            setTests={setTests}
             currTest={currTest}
-            setCurrTest={setCurrTest}
           />
         )}
         {isScriptModal && (
           <ScriptModal
             setIsScriptModal={setIsScriptModal}
             currScript={currScript}
+          />
+        )}
+        {isArchiveModal && (
+          <ArchiveModal
+            setIsArchiveModal={setIsArchiveModal}
+            archiveTestName={archiveTestName}
           />
         )}
         <div className="mt-10 max-w-4xl mx-auto">
@@ -136,10 +143,14 @@ function TestList({ currTest, setCurrTest }) {
                           </div>
                           {test.id === menu ? (
                             <Menu
-                              name={test.name}
+                              test={test}
                               setMenu={setMenu}
+                              tests={tests}
+                              setTests={setTests}
                               setCurrScript={setCurrScript}
                               setIsScriptModal={setIsScriptModal}
+                              setIsArchiveModal={setIsArchiveModal}
+                              setArchiveTestName={setArchiveTestName}
                             />
                           ) : null}
                         </div>

--- a/dashboard/frontend/src/constants/constants.js
+++ b/dashboard/frontend/src/constants/constants.js
@@ -1,0 +1,14 @@
+const ARCHIVE = "edamame-load-tests";
+const DEFAULT_AWS_S3_STORAGE_CLASS = "STANDARD";
+const VALID_STORAGE_CLASSES = {
+  STANDARD: "Standard",
+  REDUCED_REDUNDANCY: "Reduced Redundancy",
+  STANDARD_IA: "Standard Infrequent Access",
+  ONEZONE_IA: "One Zone Infrequent Access",
+  INTELLIGENT_TIERING: "Standard Intelligent-Tiering",
+  GLACIER: "Glacier Flexible Retrieval",
+  DEEP_ARCHIVE: "Glacier Deep Archive",
+  GLACIER_IR: "Glacier Instant Retrieval",
+};
+
+export { ARCHIVE, DEFAULT_AWS_S3_STORAGE_CLASS, VALID_STORAGE_CLASSES };

--- a/dashboard/frontend/src/services/testService.js
+++ b/dashboard/frontend/src/services/testService.js
@@ -9,6 +9,7 @@ const testService = {
       console.log(`Error fetching data: ${error}`);
     }
   },
+
   async startTest(title, script) {
     try {
       await axios.post("/tests", {
@@ -19,6 +20,7 @@ const testService = {
       console.log(`Error uploading a test: ${error}`);
     }
   },
+
   async stopTest() {
     await axios.post("/tests/stop");
   },
@@ -30,9 +32,26 @@ const testService = {
   async teardown() {
     await axios.post("/tests/teardown");
   },
+
   async getTest(name) {
     const { data } = await axios.get(`/tests/${name}`);
     return data;
+  },
+
+  async archiveExists(name) {
+    const { data } = await axios.get(`/tests/archive/${name}`);
+    return data;
+  },
+
+  async archiveTest(testName, storageClass) {
+    const res = await axios.post(
+      `/tests/archive/${testName}?storage=${storageClass}`
+    );
+    return res.data;
+  },
+
+  async deleteTestFromArchive(testName) {
+    await axios.delete(`/tests/archive/${testName}`);
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "scripts": {
     "test:utilities": "jest --testPathPattern=src/__tests__/cli/utilities",
-    "test:manifest": "jest --testPathPattern=src/__tests__/cli/manifests",
-    "test:commands": "jest --testPathPattern=src/__tests__/cli/commands"
+    "test:manifest": "jest --testPathPattern=src/__tests__/cli/manifests"
   },
   "keywords": [],
   "license": "ISC",

--- a/src/commands/portForwardGrafana.js
+++ b/src/commands/portForwardGrafana.js
@@ -14,17 +14,14 @@ const portForwardGrafana = async () => {
       spinner.fail(message);
     } else {
       spinner.succeed(
-        `You can access grafana at http://localhost:${GRAF_PORT}. ` +
-        `If you want to navigate directly to Edamame's WebSocket and ` +
-        `HTTP metrics dashboard, that's available at ${grafana.detailedUrl()}. ` +
-        `Simply replace the "yourSpecificTestName" query parameter ` +
-        `with an existing historical test name.`
+        `You can access grafana at http://localhost:${GRAF_PORT}.\n` +
+          `Edamame's WebSocket & HTTP metrics dashboard is available at:\n ` +
+          `${grafana.detailedUrl()}\n Simply replace the "yourSpecificTestName"` +
+          ` query parameter with an existing historical test name.`
       );
     }
   } catch (err) {
-    spinner.fail(
-      `Error port forwardng to Grafana: ${err.message}`
-    );
+    spinner.fail(`Error port forwardng to Grafana: ${err.message}`);
     if (err["stdout"]) console.log(err["stdout"]);
   }
 };

--- a/src/commands/restore.js
+++ b/src/commands/restore.js
@@ -20,7 +20,7 @@ const restore = async (options) => {
         ? "intelligent_tiering"
         : "glacier";
       if (type === "glacier") {
-        if (isNaN(numDays) || numDays < 0 || numDays > 30 || days.match(".")) {
+        if (isNaN(numDays) || numDays < 0 || numDays > 30 || days.match(/\./)) {
           throw Error(archiveMessage.invalidRestoreDays(days));
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,7 @@ program
       await portForwardGrafana();
       startGui();
     } else if (options.stop) {
+      await stopGrafana();
       stopGui();
     }
   });

--- a/src/utilities/archiveMessage.js
+++ b/src/utilities/archiveMessage.js
@@ -34,8 +34,8 @@ const archiveMessage = {
 
   restorationInProgress(name) {
     return (
-      `AWS S3 restoration process is in progress. Once its complete you ` +
-      ` can import data associated with ${name} into your current Edamame ` +
+      `AWS S3 restoration process is in progress. Once its complete you` +
+      ` can import data associated with ${name} into your current Edamame` +
       ` EKS cluster or move the S3 object elsewhere.`
     );
   },
@@ -116,7 +116,7 @@ const archiveMessage = {
     return `Successfully deleted ${name} from your Edamame load test AWS S3 Bucket.`;
   },
 
-  singleImportFail(name) {
+  singleImportFail(testName) {
     return `Issue importing ${testName}. Please try again later.`;
   },
 


### PR DESCRIPTION
updates:
- update react UI to add archive option to menu modal that when clicked opens up archive specific modal components
- the added archive UI modal components allow for adding a test to the AWS S3 archive with any of the available S3 storage classes and allow for deleting a test from the AWS S3 archive
- currently, can't import a test from the react UI archive modal b/c importing is intended to be done immediately after edamame init executes
- add jest tests for the new react ui features
- update cli dashboard stop command to automatically stop grafana dashboard so that grafana process isn't lingering b/c cli dashboard start command initializes both grafana and the react ui